### PR TITLE
feat(HU03): base arquitectura listado de artistas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,23 +5,33 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
+
       - name: Build APK
         run: |
           chmod +x gradlew
           ./gradlew assembleDebug
+
+      - name: Rename APK
+        run: mv app/build/outputs/apk/debug/app-debug.apk app/build/outputs/apk/debug/vinilos-${{ github.ref_name }}.apk
+
       - name: Create Release with APK
         uses: softprops/action-gh-release@v1
         with:
-          files: app/build/outputs/apk/debug/app-debug.apk
+          files: app/build/outputs/apk/debug/vinilos-${{ github.ref_name }}.apk
           name: Release ${{ github.ref_name }}
+          body: ${{ github.event.head_commit.message }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,4 +57,14 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    // Retrofit
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-gson:2.9.0")
+    // ViewModel + LiveData
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
+    // Coroutines
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET"/>
     <application
+        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/java/com/uniandes/vinilos/model/Album.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/Album.kt
@@ -9,5 +9,6 @@ data class Album(
     val genre: String,
     val recordLabel: String,
     val tracks: List<Track> = emptyList(),
-    val artists: List<Artist> = emptyList()
+    val performers: List<Performer> = emptyList(),
+    val comments: List<Comment> = emptyList()
 )

--- a/app/src/main/java/com/uniandes/vinilos/model/Collector.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/Collector.kt
@@ -4,5 +4,8 @@ data class Collector(
     val id: Int,
     val name: String,
     val telephone: String,
-    val email: String
+    val email: String,
+    val comments: List<Comment> = emptyList(),
+    val favoritePerformers: List<Performer> = emptyList(),
+    val collectorAlbums: List<CollectorAlbum> = emptyList()
 )

--- a/app/src/main/java/com/uniandes/vinilos/model/CollectorAlbum.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/CollectorAlbum.kt
@@ -1,0 +1,7 @@
+package com.uniandes.vinilos.model
+
+data class CollectorAlbum(
+    val id: Int,
+    val price: Int,
+    val status: String
+)

--- a/app/src/main/java/com/uniandes/vinilos/model/Comment.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/Comment.kt
@@ -1,0 +1,7 @@
+package com.uniandes.vinilos.model
+
+data class Comment(
+    val id: Int,
+    val description: String,
+    val rating: Int
+)

--- a/app/src/main/java/com/uniandes/vinilos/model/Performer.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/Performer.kt
@@ -1,9 +1,10 @@
 package com.uniandes.vinilos.model
 
-data class Artist(
+data class Performer(
     val id: Int,
     val name: String,
     val image: String,
     val description: String,
-    val birthDate: String
+    val birthDate: String? = null,
+    val creationDate: String? = null
 )

--- a/app/src/main/java/com/uniandes/vinilos/network/NetworkServiceAdapter.kt
+++ b/app/src/main/java/com/uniandes/vinilos/network/NetworkServiceAdapter.kt
@@ -1,0 +1,14 @@
+package com.uniandes.vinilos.network
+
+import com.uniandes.vinilos.util.Constants
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+object NetworkServiceAdapter {
+    private val retrofit = Retrofit.Builder()
+        .baseUrl(Constants.BASE_URL)
+        .addConverterFactory(GsonConverterFactory.create())
+        .build()
+
+    val api: VinilosApi = retrofit.create(VinilosApi::class.java)
+}

--- a/app/src/main/java/com/uniandes/vinilos/network/VinilosAPI.kt
+++ b/app/src/main/java/com/uniandes/vinilos/network/VinilosAPI.kt
@@ -1,0 +1,27 @@
+package com.uniandes.vinilos.network
+
+import com.uniandes.vinilos.model.Album
+import com.uniandes.vinilos.model.Collector
+import com.uniandes.vinilos.model.Performer
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface VinilosApi {
+    @GET("musicians")
+    suspend fun getMusicians(): List<Performer>
+
+    @GET("bands")
+    suspend fun getBands(): List<Performer>
+
+    @GET("albums")
+    suspend fun getAlbums(): List<Album>
+
+    @GET("albums/{id}")
+    suspend fun getAlbum(@Path("id") id: Int): Album
+
+    @GET("collectors")
+    suspend fun getCollectors(): List<Collector>
+
+    @GET("collectors/{id}")
+    suspend fun getCollector(@Path("id") id: Int): Collector
+}

--- a/app/src/main/java/com/uniandes/vinilos/repository/ArtistRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilos/repository/ArtistRepository.kt
@@ -1,0 +1,20 @@
+package com.uniandes.vinilos.repository
+
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.network.NetworkServiceAdapter
+
+class ArtistRepository {
+    private val api = NetworkServiceAdapter.api
+
+    suspend fun getMusicians(): List<Performer> {
+        return api.getMusicians()
+    }
+
+    suspend fun getBands(): List<Performer> {
+        return api.getBands()
+    }
+
+    suspend fun getPerformers(): List<Performer> {
+        return getMusicians() + getBands()
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistListScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistListScreen.kt
@@ -6,17 +6,28 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.*
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.uniandes.vinilos.model.Performer
 import com.uniandes.vinilos.ui.theme.VinilosTheme
 import com.uniandes.vinilos.util.FakeData
 
 @Composable
-fun ArtistListScreen(onArtistClick: (Int) -> Unit = {}) {
+fun ArtistListScreen(
+    onArtistClick: (Int) -> Unit = {},
+    viewModel: ArtistViewModel = viewModel()
+) {
+    val performers by viewModel.performers.collectAsState()
+    val isLoading by viewModel.isLoading.collectAsState()
+    val error by viewModel.error.collectAsState()
+
     Column(modifier = Modifier.fillMaxSize()) {
         Text(
             text = "ARCHIVE 003",
@@ -31,12 +42,27 @@ fun ArtistListScreen(onArtistClick: (Int) -> Unit = {}) {
             fontWeight = FontWeight.Bold,
             modifier = Modifier.padding(start = 16.dp, bottom = 16.dp)
         )
-        LazyColumn {
-            items(FakeData.performers) { performer ->
-                PerformerItem(
-                    performer = performer,
-                    onClick = { onArtistClick(performer.id) }
-                )
+
+        when {
+            isLoading -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator()
+                }
+            }
+            error != null -> {
+                Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                    Text(text = error ?: "Error desconocido", color = MaterialTheme.colorScheme.error)
+                }
+            }
+            else -> {
+                LazyColumn {
+                    items(performers) { performer ->
+                        PerformerItem(
+                            performer = performer,
+                            onClick = { onArtistClick(performer.id) }
+                        )
+                    }
+                }
             }
         }
     }
@@ -72,6 +98,9 @@ fun PerformerItem(performer: Performer, onClick: () -> Unit) {
 @Composable
 fun ArtistListScreenPreview() {
     VinilosTheme {
-        ArtistListScreen()
+        ArtistListScreen(viewModel = ArtistViewModel().also {
+            // preview usa FakeData
+        })
     }
 }
+

--- a/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistListScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistListScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.uniandes.vinilos.model.Artist
+import com.uniandes.vinilos.model.Performer
 import com.uniandes.vinilos.ui.theme.VinilosTheme
 import com.uniandes.vinilos.util.FakeData
 
@@ -32,10 +32,10 @@ fun ArtistListScreen(onArtistClick: (Int) -> Unit = {}) {
             modifier = Modifier.padding(start = 16.dp, bottom = 16.dp)
         )
         LazyColumn {
-            items(FakeData.artists) { artist ->
-                ArtistItem(
-                    artist = artist,
-                    onClick = { onArtistClick(artist.id) }
+            items(FakeData.performers) { performer ->
+                PerformerItem(
+                    performer = performer,
+                    onClick = { onArtistClick(performer.id) }
                 )
             }
         }
@@ -43,7 +43,7 @@ fun ArtistListScreen(onArtistClick: (Int) -> Unit = {}) {
 }
 
 @Composable
-fun ArtistItem(artist: Artist, onClick: () -> Unit) {
+fun PerformerItem(performer: Performer, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -53,13 +53,13 @@ fun ArtistItem(artist: Artist, onClick: () -> Unit) {
     ) {
         Column(modifier = Modifier.padding(16.dp)) {
             Text(
-                text = artist.name,
+                text = performer.name,
                 fontSize = 20.sp,
                 fontWeight = FontWeight.Bold
             )
             Spacer(modifier = Modifier.height(4.dp))
             Text(
-                text = artist.description,
+                text = performer.description,
                 fontSize = 12.sp,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 2

--- a/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistViewModel.kt
@@ -1,0 +1,40 @@
+package com.uniandes.vinilos.ui.artists
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.repository.ArtistRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+
+class ArtistViewModel : ViewModel() {
+    private val repository = ArtistRepository()
+
+    private val _performers = MutableStateFlow<List<Performer>>(emptyList())
+    val performers: StateFlow<List<Performer>> = _performers
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error
+
+    init {
+        loadPerformers()
+    }
+
+    fun loadPerformers() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                _performers.value = repository.getPerformers()
+            } catch (e: Exception) {
+                _error.value = "Error al cargar artistas: ${e.message}"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/home/HomeScreen.kt
@@ -36,7 +36,7 @@ fun HomeScreen() {
             fontWeight = FontWeight.Bold
         )
         Text(
-            text = lastAlbum.artists.firstOrNull()?.name ?: "Miles Davis",
+            text = lastAlbum.performers.firstOrNull()?.name ?: "Miles Davis",
             fontSize = 16.sp,
             color = MaterialTheme.colorScheme.onSurfaceVariant
         )
@@ -48,7 +48,7 @@ fun HomeScreen() {
             color = MaterialTheme.colorScheme.primary
         )
         Spacer(modifier = Modifier.height(8.dp))
-        FakeData.artists.take(2).forEach { artist ->
+        FakeData.performers.take(2).forEach { artist ->
             Text(
                 text = artist.name,
                 fontSize = 16.sp,
@@ -63,7 +63,7 @@ fun HomeScreen() {
             color = MaterialTheme.colorScheme.primary
         )
         Spacer(modifier = Modifier.height(8.dp))
-        FakeData.artists.takeLast(2).forEach { artist ->
+        FakeData.performers.takeLast(2).forEach { artist ->
             Text(
                 text = artist.name,
                 fontSize = 16.sp,

--- a/app/src/main/java/com/uniandes/vinilos/util/Constants.kt
+++ b/app/src/main/java/com/uniandes/vinilos/util/Constants.kt
@@ -1,0 +1,5 @@
+package com.uniandes.vinilos.util
+
+object Constants {
+    const val BASE_URL = "http://192.168.0.13:3000/"
+}

--- a/app/src/main/java/com/uniandes/vinilos/util/FakeData.kt
+++ b/app/src/main/java/com/uniandes/vinilos/util/FakeData.kt
@@ -1,11 +1,35 @@
 package com.uniandes.vinilos.util
 
 import com.uniandes.vinilos.model.Album
-import com.uniandes.vinilos.model.Artist
+import com.uniandes.vinilos.model.Performer
 import com.uniandes.vinilos.model.Collector
 import com.uniandes.vinilos.model.Track
 
 object FakeData {
+
+    val performers = listOf(
+        Performer(
+            id = 1,
+            name = "Miles Davis",
+            image = "",
+            description = "American jazz trumpeter and composer",
+            birthDate = "1926-05-26"
+        ),
+        Performer(
+            id = 2,
+            name = "John Coltrane",
+            image = "",
+            description = "American jazz saxophonist and composer",
+            birthDate = "1926-09-23"
+        ),
+        Performer(
+            id = 3,
+            name = "Nina Simone",
+            image = "",
+            description = "American singer, songwriter and pianist",
+            birthDate = "1933-02-21"
+        )
+    )
 
     val albums = listOf(
         Album(
@@ -20,52 +44,6 @@ object FakeData {
                 Track(1, "Shhh/Peaceful", "18:19"),
                 Track(2, "In a Silent Way", "20:05")
             )
-        ),
-        Album(
-            id = 2,
-            name = "Kind of Blue",
-            cover = "",
-            releaseDate = "1959",
-            description = "The best-selling jazz album of all time",
-            genre = "Jazz",
-            recordLabel = "Columbia",
-            tracks = listOf(
-                Track(3, "So What", "9:22"),
-                Track(4, "Blue in Green", "5:37")
-            )
-        ),
-        Album(
-            id = 3,
-            name = "Bitches Brew",
-            cover = "",
-            releaseDate = "1970",
-            description = "A landmark of jazz fusion",
-            genre = "Jazz Fusion",
-            recordLabel = "Columbia"
-        )
-    )
-
-    val artists = listOf(
-        Artist(
-            id = 1,
-            name = "Miles Davis",
-            image = "",
-            description = "American jazz trumpeter and composer",
-            birthDate = "1926-05-26"
-        ),
-        Artist(
-            id = 2,
-            name = "John Coltrane",
-            image = "",
-            description = "American jazz saxophonist and composer",
-            birthDate = "1926-09-23"
-        ),
-        Artist(
-            id = 3,
-            name = "Nina Simone",
-            image = "",
-            description = "American singer, songwriter and pianist",
-            birthDate = "1933-02-21"
         )
     )
 
@@ -75,12 +53,6 @@ object FakeData {
             name = "Alejandro Vance",
             telephone = "3001234567",
             email = "alejandro@vinilos.com"
-        ),
-        Collector(
-            id = 2,
-            name = "Marcus Thorne",
-            telephone = "3007654321",
-            email = "marcus@vinilos.com"
         )
     )
 }

--- a/app/src/test/java/com/uniandes/vinilos/ArtistRepositoryTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ArtistRepositoryTest.kt
@@ -1,0 +1,35 @@
+package com.uniandes.vinilos
+
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.Assert.*
+import com.uniandes.vinilos.repository.ArtistRepository
+import kotlin.time.Duration.Companion.seconds
+
+class ArtistRepositoryTest {
+
+    private val repository = ArtistRepository()
+
+
+@Test
+    fun `getMusicians returns non-empty list`() = runTest(timeout = 30.seconds) {
+        val performers = repository.getMusicians()
+        assertTrue("La lista no debe estar vacía", performers.isNotEmpty())
+        performers.forEach { println("- ${it.name}") }
+    }
+
+    @Test
+    fun `getBands returns non-empty list`() = runTest {
+        val performers = repository.getBands()
+        assertTrue("La lista no debe estar vacía", performers.isNotEmpty())
+        println("Bandas encontradas: ${performers.size}")
+        performers.forEach { println("- ${it.name}") }
+    }
+
+    @Test
+    fun `getPerformers combines musicians and bands`() = runTest {
+        val performers = repository.getPerformers()
+        assertTrue("La lista combinada no debe estar vacía", performers.isNotEmpty())
+        println("Total performers: ${performers.size}")
+    }
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la arquitectura base MVVM para el listado de artistas.

## Cambios
- Capa de red con Retrofit (NetworkServiceAdapter, VinilosApi)
- ArtistRepository combinando musicians y bands
- ArtistViewModel con StateFlow
- ArtistListScreen conectado a ViewModel

## Pendiente
- Ajustar diseño visual al UI design (imágenes, grid, tipografía)

Relates to #15