### PR TITLE
Feature/hu05 listado coleccionistas

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,6 @@ on:
 permissions:
   contents: write
 
-permissions:
-  contents: write
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <img src="https://github.com/TU_ORG/TU_REPO/actions/workflows/NOMBRE_WORKFLOW.yml/badge.svg" alt="CI"/>
+  <img src="https://github.com/joseph-burbano/TSDC_VinilosMobileAPP/actions/workflows/ci.yml/badge.svg" alt="CI"/>
   <img src="https://img.shields.io/badge/Android-3DDC84?style=flat&logo=android&logoColor=white" alt="Android"/>
   <img src="https://img.shields.io/badge/Kotlin-7F52FF?style=flat&logo=kotlin&logoColor=white" alt="Kotlin"/>
   <img src="https://img.shields.io/badge/Jetpack%20Compose-4285F4?style=flat&logo=jetpackcompose&logoColor=white" alt="Jetpack Compose"/>
@@ -190,13 +190,19 @@ Ubicación: `app/src/test/java/com/uniandes/vinilos/`.
 
 ### Qué cubren
 
-| Suite                  | Archivo                              | Casos | Qué valida                                                                                   |
-| ---------------------- | ------------------------------------ | ----- | -------------------------------------------------------------------------------------------- |
-| ArtistRepositoryTest   | `repository/ArtistRepositoryTest.kt` | 4     | Cache-first (DAO → API), combina músicos y bandas, refresh borra y refetchea                 |
-| AlbumRepositoryTest    | `repository/AlbumRepositoryTest.kt`  | 8     | Patrón cache-first, mapeo DTO → modelo, `releaseDate` ISO truncado al año, `refreshAlbums()` |
-| AlbumViewModelTest     | `ui/albums/AlbumViewModelTest.kt`    | 9     | Estados Loading/Success/Error, `IOException`, `HttpException`, refresh, `findById`           |
-| VinilosApiContractTest | `network/VinilosApiContractTest.kt`  | 3     | Contrato HTTP `GET /albums` con MockWebServer                                                |
-| ExampleUnitTest        | `ExampleUnitTest.kt`                 | 1     | Smoke del runner                                                                             |
+| Suite                        | Archivo                                         | Casos | Qué valida                                                                                   |
+| ---------------------------- | ----------------------------------------------- | ----- | -------------------------------------------------------------------------------------------- |
+| ArtistViewModelTest          | `ui/artists/ArtistViewModelTest.kt`             | 13    | Carga, paginación, refresh, errores, findById                                                |
+| ArtistViewModelDetailTest    | `ui/artists/ArtistViewModelDetailTest.kt`       | 5     | findById con álbumes, null, diferenciación                                                   |
+| ArtistRepositoryTest         | `repository/ArtistRepositoryTest.kt`            | 4     | Cache-first (DAO → API), combina músicos y bandas, refresh borra y refetchea                 |
+| AlbumRepositoryTest          | `repository/AlbumRepositoryTest.kt`             | 8     | Patrón cache-first, mapeo DTO → modelo, `releaseDate` ISO truncado al año, `refreshAlbums()` |
+| AlbumViewModelTest           | `ui/albums/AlbumViewModelTest.kt`               | 9     | Estados Loading/Success/Error, `IOException`, `HttpException`, refresh, `findById`           |
+| AlbumViewModelDetailTest     | `ui/albums/AlbumViewModelDetailTest.kt`         | 7     | findById con tracks, performers, null                                                        |
+| CollectorViewModelTest       | `ui/collectors/CollectorViewModelTest.kt`       | 12    | Carga, paginación, refresh, errores, loadCollector                                           |
+| CollectorViewModelDetailTest | `ui/collectors/CollectorViewModelDetailTest.kt` | 7     | findById con álbumes, performers, null                                                       |
+| CollectorRepositoryTest      | `repository/CollectorRepositoryTest.kt`         | 9     | Cache-first, `getCollector(id)` individual, refresh, excepciones del API, null si falla      |
+| VinilosApiContractTest       | `network/VinilosApiContractTest.kt`             | 3     | Contrato HTTP `GET /albums` con MockWebServer                                                |
+| ExampleUnitTest              | `ExampleUnitTest.kt`                            | 1     | Smoke del runner                                                                             |
 
 ### Cómo correrlas
 
@@ -233,11 +239,18 @@ Ubicación: `app/src/androidTest/java/com/uniandes/vinilos/`.
 
 ### Qué cubren
 
-| HU   | Suite                             | Casos | Qué valida                                                                                                                                                              |
-| ---- | --------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| HU01 | AlbumListScreenInstrumentedTest   | 5     | Skeleton durante carga, render del listado, mensaje de error, botón "Reintentar", estado vacío                                                                          |
-| HU02 | AlbumDetailScreenInstrumentedTest | 5     | Spinner mientras carga, render completo del detalle (título, género, año, sello, secciones ARTISTAS y CANCIONES), botón Volver, mensaje de error, "Álbum no encontrado" |
-| HU03 | ArtistListScreenTest              | 4     | Spinner durante carga, nombres de artistas, grilla con testTags, mensaje de error                                                                                       |
+| HU   | Suite                                 | Casos | Qué valida                                                                                                                                                              |
+| ---- | ------------------------------------- | ----- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| HU01 | AlbumListScreenInstrumentedTest       | 5     | Skeleton durante carga, render del listado, mensaje de error, botón "Reintentar", estado vacío                                                                          |
+| HU02 | AlbumDetailScreenInstrumentedTest     | 5     | Spinner mientras carga, render completo del detalle (título, género, año, sello, secciones ARTISTAS y CANCIONES), botón Volver, mensaje de error, "Álbum no encontrado" |
+| HU03 | ArtistListScreenInstrumentedTest      | 4     | Spinner durante carga, nombres de artistas, grilla con testTags, mensaje de error                                                                                       |
+| HU04 | ArtistDetailScreenInstrumentedTest    | 5     | Loading, nombre, stats, vault, botón volver                                                                                                                             |
+| HU05 | CollectorListScreenInstrumentedTest   | 13    | Loading, coleccionistas, búsqueda, paginación, navegación                                                                                                               |
+| HU06 | CollectorDetailScreenInstrumentedTest | 6     |
+
+Loading, nombre, stats, vault, botón volver
+
+                                                                                       |
 
 ### Cómo correrlas
 
@@ -271,12 +284,15 @@ Pruebas de **caja negra** sobre el APK real, dirigidas con Cucumber + Kraken-Nod
 
 ### Qué cubren
 
-| HU   | Feature              | Archivo                                | Qué valida                                                                           |
-| ---- | -------------------- | -------------------------------------- | ------------------------------------------------------------------------------------ |
-| HU01 | Listado de álbumes   | `kraken/features/album_list.feature`   | Navegar al catálogo, ver el header y confirmar que un álbum aparece en la lista      |
-| HU02 | Detalle de álbum     | `kraken/features/album_detail.feature` | Tap en un álbum, verificar género, secciones ARTISTAS y CANCIONES, volver con Volver |
-| HU03 | Listado de artistas  | `kraken/features/artist_list.feature`  | Navega al listado de artistas y verifica su contenido                                |
-| —    | Navegación principal | `kraken/features/navbar.feature`       | Las 4 tabs son visibles y navegables                                                 |
+| HU   | Feature                   | Archivo                                    | Qué valida                                                                           |
+| ---- | ------------------------- | ------------------------------------------ | ------------------------------------------------------------------------------------ |
+| HU01 | Listado de álbumes        | `kraken/features/album_list.feature`       | Navegar al catálogo, ver el header y confirmar que un álbum aparece en la lista      |
+| HU02 | Detalle de álbum          | `kraken/features/album_detail.feature`     | Tap en un álbum, verificar género, secciones ARTISTAS y CANCIONES, volver con Volver |
+| HU03 | Listado de artistas       | `kraken/features/artist_list.feature`      | Navega al listado de artistas y verifica su contenido                                |
+| HU04 | Detalle de artista        | `kraken/features/artist_detail.feature`    | Tap en artista, ver secciones, volver                                                |
+| HU05 | Listado de coleccionistas | `kraken/features/collector_list.feature`   | Navegar al listado, ver header y coleccionista                                       |
+| HU06 | Detalle de coleccionista  | `kraken/features/collector_detail.feature` | Tap en coleccionista, ver ELITE CURATOR y The Vault, volver                          |
+| —    | Navegación principal      | `kraken/features/navbar.feature`           | Las 4 tabs son visibles y navegables                                                 |
 
 ### Setup inicial (una sola vez por máquina)
 

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/collectors/CollectorDetailScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/collectors/CollectorDetailScreenInstrumentedTest.kt
@@ -17,7 +17,6 @@ import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import io.mockk.coVerify
 
 @RunWith(AndroidJUnit4::class)
 class CollectorDetailScreenInstrumentedTest {
@@ -168,53 +167,4 @@ class CollectorDetailScreenInstrumentedTest {
         composeTestRule.onNodeWithTag(CollectorDetailTestTags.BACK).performClick()
         assertTrue(backInvoked)
     }
-
-    @Test
-fun `loadCollector agrega el coleccionista a _collectors si no estaba`() = runTest {
-    val repo = mockk<CollectorRepository>(relaxed = true)
-    coEvery { repo.getCollectors() } returns emptyList()
-    coEvery { repo.getCollector(99) } returns Collector(
-        id = 99, name = "Nuevo Collector",
-        telephone = "3009999999", email = "nuevo@vinilos.com"
-    )
-
-    val vm = CollectorViewModel(repo)
-    advanceUntilIdle()
-
-    vm.loadCollector(99)
-    advanceUntilIdle()
-
-    assertEquals(1, vm.collectors.value.size)
-    assertEquals("Nuevo Collector", vm.collectors.value.first().name)
-}
-
-@Test
-fun `loadCollector no llama al repository si el id ya existe en _collectors`() = runTest {
-    val repo = mockk<CollectorRepository>(relaxed = true)
-    coEvery { repo.getCollectors() } returns listOf(collectorSample)
-
-    val vm = CollectorViewModel(repo)
-    advanceUntilIdle()
-
-    vm.loadCollector(collectorSample.id)
-    advanceUntilIdle()
-
-    coVerify(exactly = 0) { repo.getCollector(any()) }
-    assertEquals(1, vm.collectors.value.size)
-}
-
-@Test
-fun `loadCollector no agrega nada si el repository devuelve null`() = runTest {
-    val repo = mockk<CollectorRepository>(relaxed = true)
-    coEvery { repo.getCollectors() } returns emptyList()
-    coEvery { repo.getCollector(99) } returns null
-
-    val vm = CollectorViewModel(repo)
-    advanceUntilIdle()
-
-    vm.loadCollector(99)
-    advanceUntilIdle()
-
-    assertTrue(vm.collectors.value.isEmpty())
-}
 }

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/collectors/CollectorListScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/collectors/CollectorListScreenInstrumentedTest.kt
@@ -1,0 +1,334 @@
+package com.uniandes.vinilos.ui.collectors
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.vinilos.model.Collector
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.repository.CollectorRepository
+import com.uniandes.vinilos.ui.theme.VinilosTheme
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CollectorListScreenInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val fakeCollectors = listOf(
+        Collector(
+            id = 100,
+            name = "Manolo Bellon",
+            telephone = "3502457896",
+            email = "manollo@caracol.com.co",
+            favoritePerformers = listOf(
+                Performer(100, "Rubén Blades Bellido de Luna", "", "Cantante panameño", "1948-07-16")
+            )
+        ),
+        Collector(
+            id = 101,
+            name = "Jaime Monsalve",
+            telephone = "3012357936",
+            email = "jmonsalve@rtvc.com.co",
+            favoritePerformers = listOf(
+                Performer(101, "Queen", "", "Banda británica", null, "1970-01-01")
+            )
+        )
+    )
+
+    private fun createViewModel(
+        collectors: List<Collector> = fakeCollectors
+    ): CollectorViewModel {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns collectors
+        return CollectorViewModel(repo)
+    }
+
+    // ── Carga ─────────────────────────────────────────────────────────────────
+
+    @Test
+    fun listScreen_muestraIndicadorDeCarga_inicialmente() {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } coAnswers {
+            delay(2_000)
+            fakeCollectors
+        }
+        val viewModel = CollectorViewModel(repo)
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                CollectorListScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag("collector_list_loading")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun listScreen_muestraNombresDeColeccionistas_cuandoCargaExitosa() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                CollectorListScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText("Manolo Bellon").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
+        composeTestRule.onNodeWithText("2 encontrados").assertIsDisplayed()
+    }
+
+    @Test
+    fun listScreen_muestraArtistaFavorito_enCadaItem() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                CollectorListScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onNodeWithText("Fan de: Rubén Blades Bellido de Luna")
+            .assertIsDisplayed()
+        composeTestRule
+            .onNodeWithText("Fan de: Queen")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun listScreen_muestraMensajeDeError_cuandoFallaElServicio() {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } throws java.io.IOException("sin red")
+        val viewModel = CollectorViewModel(repo)
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                CollectorListScreen(viewModel = viewModel)
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("collector_list_error"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onNodeWithTag("collector_list_error")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun listScreen_clickEnItem_invocaCallbackConIdCorrecto() {
+        val viewModel = createViewModel()
+        var clickedId: Int? = null
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                CollectorListScreen(
+                    viewModel = viewModel,
+                    onCollectorClick = { clickedId = it }
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onNodeWithText("Manolo Bellon")
+            .performClick()
+
+        assert(clickedId == 100)
+    }
+
+    // ── Búsqueda ──────────────────────────────────────────────────────────────
+
+    @Test
+    fun listScreen_busqueda_muestraSoloCoincidencias_porNombre() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_search").performTextInput("Manolo")
+
+        composeTestRule.onNodeWithText("Manolo Bellon").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertDoesNotExist()
+    }
+
+    @Test
+    fun listScreen_busqueda_esCaseInsensitive() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_search").performTextInput("jaime")
+
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Manolo Bellon").assertDoesNotExist()
+    }
+
+    @Test
+    fun listScreen_busqueda_porArtistaFavorito() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_search").performTextInput("Queen")
+
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Manolo Bellon").assertDoesNotExist()
+    }
+
+    @Test
+    fun listScreen_busqueda_sinResultados_muestraListaVacia() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_search")
+            .performTextInput("xyz_no_existe")
+
+        composeTestRule.onNodeWithText("Manolo Bellon").assertDoesNotExist()
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertDoesNotExist()
+    }
+
+    @Test
+    fun listScreen_limpiarBusqueda_restauraListaCompleta() {
+        val viewModel = createViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_search").performTextInput("Manolo")
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertDoesNotExist()
+
+        composeTestRule.onNodeWithTag("collector_search").performTextClearance()
+
+        composeTestRule.onNodeWithText("Manolo Bellon").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Jaime Monsalve").assertIsDisplayed()
+    }
+
+    // ── Paginación ────────────────────────────────────────────────────────────
+
+    @Test
+    fun listScreen_botonMostrarMas_visibleCuandoHayMas() {
+        val manyCollectors = (1..5).map {
+            Collector(it, "Collector $it", telephone = "", email = "c$it@test.com")
+        }
+        val viewModel = createViewModel(manyCollectors)
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_load_more"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_load_more").assertIsDisplayed()
+    }
+
+    @Test
+    fun listScreen_botonMostrarMas_noVisibleConPocosDatos() {
+        val viewModel = createViewModel(fakeCollectors) // solo 2 < pageSize(4)
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_list"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_load_more").assertDoesNotExist()
+    }
+
+    @Test
+    fun listScreen_botonMostrarMas_seOcultaAlBuscar() {
+        val manyCollectors = (1..5).map {
+            Collector(it, "Collector $it", telephone = "", email = "c$it@test.com")
+        }
+        val viewModel = createViewModel(manyCollectors)
+
+        composeTestRule.setContent {
+            VinilosTheme { CollectorListScreen(viewModel = viewModel) }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule.onAllNodes(hasTestTag("collector_load_more"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag("collector_load_more").assertIsDisplayed()
+
+        composeTestRule.onNodeWithTag("collector_search").performTextInput("Collector")
+        composeTestRule.onNodeWithTag("collector_load_more").assertDoesNotExist()
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorDetailScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorDetailScreen.kt
@@ -148,13 +148,15 @@ private fun HeroSection(collector: Collector) {
             )
         }
         Spacer(Modifier.height(16.dp))
-        Text(
-            "REGISTRY ID: #${collector.id.toString().padStart(6, '0')}",
-            color = MaterialTheme.colorScheme.primary,
-            fontSize = 11.sp,
-            letterSpacing = 1.5.sp,
-            fontWeight = FontWeight.SemiBold
-        )
+        if (!collector.email.isNullOrBlank()) {
+            Text(
+                collector.email!!,
+                color = MaterialTheme.colorScheme.primary,
+                fontSize = 11.sp,
+                letterSpacing = 1.5.sp,
+                fontWeight = FontWeight.SemiBold
+            )
+        }
         Spacer(Modifier.height(4.dp))
         Text(
             collector.name,

--- a/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorListScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorListScreen.kt
@@ -1,73 +1,186 @@
 package com.uniandes.vinilos.ui.collectors
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.uniandes.vinilos.model.Collector
+import com.uniandes.vinilos.ui.theme.VinilosTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CollectorListScreen(
-    viewModel: CollectorViewModel,
+    viewModel: CollectorViewModel = viewModel(
+        factory = CollectorViewModel.factory(LocalContext.current)
+    ),
     onCollectorClick: (Int) -> Unit = {}
 ) {
-    val collectors by viewModel.collectors.collectAsStateWithLifecycle()
+    val visibleCollectors by viewModel.visibleCollectors.collectAsStateWithLifecycle(
+        initialValue = emptyList()
+    )
+    val hasMore by viewModel.hasMore.collectAsStateWithLifecycle(
+        initialValue = false
+    )
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val isRefreshing by viewModel.isRefreshing.collectAsStateWithLifecycle()
     val error by viewModel.error.collectAsStateWithLifecycle()
+    val allCollectors by viewModel.collectors.collectAsStateWithLifecycle()
 
-    when {
-        isLoading -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            CircularProgressIndicator(
-                modifier = Modifier.semantics { contentDescription = "collector_loading" }
-            )
+    var searchQuery by remember { mutableStateOf("") }
+
+    val displayCollectors = if (searchQuery.isBlank()) {
+        visibleCollectors
+    } else {
+        allCollectors.filter {
+            it.name.contains(searchQuery, ignoreCase = true) ||
+            it.email.orEmpty().contains(searchQuery, ignoreCase = true) ||
+            it.favoritePerformers.any { p ->
+                p.name.contains(searchQuery, ignoreCase = true)
+            }
         }
-        error != null -> Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-            Text(text = error ?: "", color = MaterialTheme.colorScheme.error)
-        }
-        else -> PullToRefreshBox(
-            isRefreshing = isRefreshing,
-            onRefresh = { viewModel.refreshCollectors() }
-        ) {
-            LazyColumn(modifier = Modifier.fillMaxSize()) {
-                item {
-                    Column(modifier = Modifier.padding(start = 16.dp, top = 16.dp, bottom = 8.dp)) {
-                        Text(
-                            text = "ARCHIVE DIRECTORY",
-                            fontSize = 11.sp,
-                            letterSpacing = 2.sp,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Text(
-                            text = "The People of\nthe Needle",
-                            fontSize = 36.sp,
-                            fontWeight = FontWeight.Bold
-                        )
-                        Text(
-                            text = "Curating the global network of archivists,\ndiggers, and auditory historians.",
-                            fontSize = 14.sp,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(top = 4.dp)
+    }
+
+    val filteredCount = if (searchQuery.isBlank()) allCollectors.size
+                        else displayCollectors.size
+
+    Surface(
+        modifier = Modifier.fillMaxSize(),
+        color = MaterialTheme.colorScheme.background
+    ) {
+        when {
+            isLoading -> Box(
+                Modifier
+                    .fillMaxSize()
+                    .testTag("collector_list_loading"),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.semantics {
+                        contentDescription = "collector_loading"
+                    }
+                )
+            }
+            error != null -> Box(
+                Modifier
+                    .fillMaxSize()
+                    .testTag("collector_list_error"),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = error ?: "", color = MaterialTheme.colorScheme.error)
+            }
+            else -> PullToRefreshBox(
+                isRefreshing = isRefreshing,
+                onRefresh = { viewModel.refreshCollectors() }
+            ) {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .testTag("collector_list"),
+                    contentPadding = PaddingValues(bottom = 32.dp)
+                ) {
+                    item {
+                        Column(
+                            modifier = Modifier.padding(
+                                start = 24.dp,
+                                end = 24.dp,
+                                top = 24.dp,
+                                bottom = 4.dp
+                            )
+                        ) {
+                            Text(
+                                text = "DIRECTORIO DE",
+                                fontSize = 12.sp,
+                                letterSpacing = 2.sp,
+                                fontWeight = FontWeight.Bold,
+                                color = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                            )
+                            var fontSize by remember { mutableStateOf(48.sp) }
+                            Text(
+                                text = "Coleccionistas",
+                                fontSize = fontSize,
+                                fontFamily = FontFamily.Serif,
+                                fontWeight = FontWeight.Medium,
+                                maxLines = 1,
+                                overflow = TextOverflow.Visible,
+                                onTextLayout = { result ->
+                                    if (result.hasVisualOverflow) {
+                                        fontSize *= 0.9f
+                                    }
+                                },
+                                modifier = Modifier.fillMaxWidth()
+                            )
+                            Text(
+                                text = "$filteredCount encontrados",
+                                fontSize = 13.sp,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .wrapContentWidth(Alignment.End)
+                            )
+                        }
+                    }
+                    item {
+                        OutlinedTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it },
+                            placeholder = { Text("Buscar coleccionistas...") },
+                            leadingIcon = {
+                                Icon(Icons.Filled.Search, contentDescription = null)
+                            },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 24.dp, vertical = 8.dp)
+                                .testTag("collector_search"),
+                            singleLine = true,
+                            shape = RoundedCornerShape(8.dp)
                         )
                     }
-                }
-                items(collectors) { collector ->
-                    CollectorItem(
-                        collector = collector,
-                        onClick = { onCollectorClick(collector.id) }
-                    )
+                    items(displayCollectors) { collector ->
+                        CollectorItem(
+                            collector = collector,
+                            onClick = { onCollectorClick(collector.id) }
+                        )
+                    }
+                    if (hasMore && searchQuery.isBlank()) {
+                        item {
+                            OutlinedButton(
+                                onClick = { viewModel.loadMore() },
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 24.dp, vertical = 12.dp)
+                                    .testTag("collector_load_more"),
+                                shape = RoundedCornerShape(4.dp)
+                            ) {
+                                Text(
+                                    text = "MOSTRAR MÁS",
+                                    letterSpacing = 2.sp,
+                                    fontSize = 12.sp
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }
@@ -79,31 +192,68 @@ fun CollectorItem(collector: Collector, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 6.dp)
+            .padding(horizontal = 24.dp, vertical = 6.dp)
             .clickable { onClick() }
             .semantics { contentDescription = "collector_item_${collector.id}" },
         elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
     ) {
-        Column(modifier = Modifier.padding(16.dp)) {
-            Text(
-                text = collector.name,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.Bold
-            )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = collector.email.orEmpty(),
-                fontSize = 12.sp,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
-            if (collector.collectorAlbums.isNotEmpty()) {
+        Row(
+            modifier = Modifier.padding(16.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(48.dp)
+                    .background(
+                        MaterialTheme.colorScheme.primary.copy(alpha = 0.15f),
+                        CircleShape
+                    ),
+                contentAlignment = Alignment.Center
+            ) {
                 Text(
-                    text = "${collector.collectorAlbums.size} álbumes en colección",
-                    fontSize = 12.sp,
+                    text = collector.name.first().uppercase(),
+                    fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(top = 4.dp)
+                    fontSize = 18.sp
                 )
             }
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = collector.name,
+                    fontSize = 18.sp,
+                    fontWeight = FontWeight.Bold,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.testTag("collector_name_${collector.id}")
+                )
+                collector.favoritePerformers.firstOrNull()?.let { performer ->
+                    Text(
+                        text = "Fan de: ${performer.name}",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.primary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+                if (collector.collectorAlbums.isNotEmpty()) {
+                    Text(
+                        text = "${collector.collectorAlbums.size} álbumes en colección",
+                        fontSize = 12.sp,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+            }
         }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+fun CollectorListScreenPreview() {
+    VinilosTheme {
+        CollectorListScreen()
     }
 }

--- a/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/collectors/CollectorViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import retrofit2.HttpException
 import java.io.IOException
+import kotlinx.coroutines.flow.combine
 
 class CollectorViewModel(
     private val repository: CollectorRepository
@@ -28,6 +29,20 @@ class CollectorViewModel(
 
     private val _error = MutableStateFlow<String?>(null)
     val error: StateFlow<String?> = _error
+
+    private val pageSize = 4
+    private val _visibleCount = MutableStateFlow(pageSize)
+    val visibleCollectors = combine(_collectors, _visibleCount) { list, count ->
+        list.take(count)
+    }
+
+    val hasMore = combine(_collectors, _visibleCount) { list, count ->
+        list.size > count
+    }
+
+    fun loadMore() {
+        _visibleCount.value += pageSize
+    }
 
     init { loadCollectors() }
 

--- a/app/src/test/java/com/uniandes/vinilos/repository/CollectorRepositoryTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/repository/CollectorRepositoryTest.kt
@@ -1,0 +1,151 @@
+package com.uniandes.vinilos.repository
+
+import com.uniandes.vinilos.database.dao.CollectorDao
+import com.uniandes.vinilos.database.entities.CollectorEntity
+import com.uniandes.vinilos.model.Collector
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.network.VinilosApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class CollectorRepositoryTest {
+
+    private lateinit var dao: CollectorDao
+    private lateinit var api: VinilosApi
+    private lateinit var repository: CollectorRepository
+
+    @Before
+    fun setup() {
+        dao = mockk(relaxed = true)
+        api = mockk(relaxed = true)
+        repository = CollectorRepository(dao, api)
+    }
+
+    @Test
+    fun `getCollectors devuelve cache cuando el DAO no esta vacio`() = runTest {
+        coEvery { dao.getAll() } returns listOf(MANOLO_ENTITY)
+
+        val result = repository.getCollectors()
+
+        assertEquals(1, result.size)
+        assertEquals("Manolo Bellon", result[0].name)
+        coVerify(exactly = 0) { api.getCollectors() }
+        coVerify(exactly = 0) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `getCollectors llama al API cuando el cache esta vacio y persiste el resultado`() = runTest {
+        coEvery { dao.getAll() } returns emptyList()
+        coEvery { api.getCollectors() } returns listOf(MANOLO_REMOTE)
+
+        val result = repository.getCollectors()
+
+        assertEquals(1, result.size)
+        assertEquals("Manolo Bellon", result.first().name)
+        coVerify(exactly = 1) { api.getCollectors() }
+        coVerify(exactly = 1) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `getCollectors conserva los favoritePerformers del API`() = runTest {
+        coEvery { dao.getAll() } returns emptyList()
+        coEvery { api.getCollectors() } returns listOf(MANOLO_REMOTE)
+
+        val collector = repository.getCollectors().first()
+
+        assertEquals(1, collector.favoritePerformers.size)
+        assertEquals("Rubén Blades Bellido de Luna", collector.favoritePerformers.first().name)
+    }
+
+    @Test
+    fun `refreshCollectors borra el cache y vuelve a llamar al API`() = runTest {
+        coEvery { api.getCollectors() } returns listOf(MANOLO_REMOTE)
+
+        repository.refreshCollectors()
+
+        coVerify(exactly = 1) { dao.deleteAll() }
+        coVerify(exactly = 1) { api.getCollectors() }
+        coVerify(exactly = 1) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `getCollectors devuelve lista vacia cuando el API devuelve vacio`() = runTest {
+        coEvery { dao.getAll() } returns emptyList()
+        coEvery { api.getCollectors() } returns emptyList()
+
+        val result = repository.getCollectors()
+
+        assertTrue(result.isEmpty())
+    }
+
+    @Test
+    fun `getCollector devuelve desde cache si existe`() = runTest {
+        coEvery { dao.findById(100) } returns MANOLO_ENTITY
+
+        val result = repository.getCollector(100)
+
+        assertEquals("Manolo Bellon", result?.name)
+        coVerify(exactly = 0) { api.getCollector(any()) }
+    }
+
+    @Test
+    fun `getCollector llama al API si no esta en cache y persiste`() = runTest {
+        coEvery { dao.findById(100) } returns null
+        coEvery { api.getCollector(100) } returns MANOLO_REMOTE
+
+        val result = repository.getCollector(100)
+
+        assertEquals("Manolo Bellon", result?.name)
+        coVerify(exactly = 1) { api.getCollector(100) }
+        coVerify(exactly = 1) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `getCollector devuelve null si el API falla`() = runTest {
+        coEvery { dao.findById(999) } returns null
+        coEvery { api.getCollector(999) } throws IOException("sin red")
+
+        val result = repository.getCollector(999)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getCollectors propaga las excepciones del API`() = runTest {
+        coEvery { dao.getAll() } returns emptyList()
+        coEvery { api.getCollectors() } throws IOException("sin red")
+
+        val thrown = org.junit.Assert.assertThrows(IOException::class.java) {
+            kotlinx.coroutines.runBlocking { repository.getCollectors() }
+        }
+        assertEquals("sin red", thrown.message)
+    }
+
+    private companion object {
+        val MANOLO_REMOTE = Collector(
+            id = 100,
+            name = "Manolo Bellon",
+            telephone = "3502457896",
+            email = "manollo@caracol.com.co",
+            favoritePerformers = listOf(
+                Performer(100, "Rubén Blades Bellido de Luna", "https://img/ruben.png",
+                    "Cantante panameño", "1948-07-16")
+            )
+        )
+
+        val MANOLO_ENTITY = CollectorEntity(
+            id = 100,
+            name = "Manolo Bellon",
+            telephone = "3502457896",
+            email = "manollo@caracol.com.co"
+        )
+    }
+}

--- a/app/src/test/java/com/uniandes/vinilos/ui/albums/AlbumViewModelDetailTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/albums/AlbumViewModelDetailTest.kt
@@ -1,6 +1,8 @@
 package com.uniandes.vinilos.ui.albums
 
 import com.uniandes.vinilos.model.Album
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.model.Track
 import com.uniandes.vinilos.repository.AlbumRepository
 import com.uniandes.vinilos.testing.MainDispatcherRule
 import io.mockk.coEvery
@@ -21,15 +23,35 @@ class AlbumViewModelDetailTest {
     @get:Rule
     val mainDispatcherRule = MainDispatcherRule()
 
+    private val trackSample = Track(
+        id = 1, name = "Come Together", duration = "4:19"
+    )
+
+    private val performerSample = Performer(
+        id = 1, name = "The Beatles",
+        image = "", description = "Banda británica",
+        creationDate = "1960-01-01"
+    )
+
     private val sample = listOf(
-        Album(1, "Abbey Road", "", "1969", "desc", "Rock", "Apple", emptyList(), emptyList()),
-        Album(2, "Thriller", "", "1982", "desc", "Pop", "Epic", emptyList(), emptyList())
+        Album(
+            id = 1, name = "Abbey Road", cover = "", releaseDate = "1969",
+            description = "Classic rock album", genre = "Rock", recordLabel = "Apple",
+            tracks = listOf(trackSample),
+            performers = listOf(performerSample)
+        ),
+        Album(
+            id = 2, name = "Thriller", cover = "", releaseDate = "1982",
+            description = "Best selling album", genre = "Pop", recordLabel = "Epic",
+            tracks = emptyList(), performers = emptyList()
+        )
     )
 
     @Test
     fun `findById devuelve el album cuando esta en Success`() = runTest {
         val repo = mockk<AlbumRepository>(relaxed = true)
         coEvery { repo.getAlbums() } returns sample
+
         val vm = AlbumViewModel(repo)
         advanceUntilIdle()
 
@@ -42,6 +64,7 @@ class AlbumViewModelDetailTest {
     fun `findById devuelve null cuando esta en Error o Loading`() = runTest {
         val repo = mockk<AlbumRepository>(relaxed = true)
         coEvery { repo.getAlbums() } throws IOException("x")
+
         val vm = AlbumViewModel(repo)
         advanceUntilIdle()
 
@@ -52,9 +75,75 @@ class AlbumViewModelDetailTest {
     fun `findById devuelve null para id inexistente`() = runTest {
         val repo = mockk<AlbumRepository>(relaxed = true)
         coEvery { repo.getAlbums() } returns sample
+
         val vm = AlbumViewModel(repo)
         advanceUntilIdle()
 
         assertNull(vm.findById(9999))
+    }
+
+    @Test
+    fun `findById retorna null mientras la lista aun no ha cargado`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.getAlbums() } returns sample
+
+        val vm = AlbumViewModel(repo)
+        // NO llamamos advanceUntilIdle
+
+        assertNull(vm.findById(1))
+    }
+
+    @Test
+    fun `findById diferencia correctamente entre dos albums con ids distintos`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.getAlbums() } returns sample
+
+        val vm = AlbumViewModel(repo)
+        advanceUntilIdle()
+
+        val resultado1 = vm.findById(1)
+        val resultado2 = vm.findById(2)
+
+        assertEquals("Abbey Road", resultado1?.name)
+        assertEquals("Thriller", resultado2?.name)
+    }
+
+    @Test
+    fun `findById retorna los tracks del album`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.getAlbums() } returns sample
+
+        val vm = AlbumViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertEquals(1, result?.tracks?.size)
+        assertEquals("Come Together", result?.tracks?.first()?.name)
+    }
+
+    @Test
+    fun `findById retorna los performers del album`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.getAlbums() } returns sample
+
+        val vm = AlbumViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertEquals(1, result?.performers?.size)
+        assertEquals("The Beatles", result?.performers?.first()?.name)
+    }
+
+    @Test
+    fun `findById retorna la descripcion correcta del album`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.getAlbums() } returns sample
+
+        val vm = AlbumViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertNotNull(result)
+        assertEquals("Classic rock album", result?.description)
     }
 }

--- a/app/src/test/java/com/uniandes/vinilos/ui/collectors/CollectorViewModelDetailTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/collectors/CollectorViewModelDetailTest.kt
@@ -1,0 +1,140 @@
+package com.uniandes.vinilos.ui.collectors
+
+import com.uniandes.vinilos.model.Album
+import com.uniandes.vinilos.model.Collector
+import com.uniandes.vinilos.model.CollectorAlbum
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.repository.CollectorRepository
+import com.uniandes.vinilos.testing.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertNotNull
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CollectorViewModelDetailTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val albumSample = Album(
+        id = 10, name = "Kind of Blue", cover = "", releaseDate = "1959",
+        description = "Jazz masterpiece", genre = "Jazz", recordLabel = "Columbia"
+    )
+
+    private val performerSample = Performer(
+        id = 100, name = "Rubén Blades Bellido de Luna",
+        image = "", description = "Cantante panameño",
+        birthDate = "1948-07-16"
+    )
+
+    private val collectorSample = Collector(
+        id = 1, name = "Alejandro Vance",
+        telephone = "3001234567", email = "alejandro@vinilos.com",
+        description = "Jazz collector",
+        favoritePerformers = listOf(performerSample),
+        collectorAlbums = listOf(
+            CollectorAlbum(id = 1, price = 100, status = "NM", album = albumSample)
+        )
+    )
+
+    private val collectorSample2 = Collector(
+        id = 2, name = "Marcus Thorne",
+        telephone = "3007654321", email = "marcus@vinilos.com"
+    )
+
+    @Test
+    fun `findById retorna el coleccionista correcto cuando esta en la lista cargada`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample, collectorSample2)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertEquals(collectorSample, result)
+        assertEquals("Alejandro Vance", result?.name)
+    }
+
+    @Test
+    fun `findById retorna los albums del coleccionista`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertEquals(1, result?.collectorAlbums?.size)
+        assertEquals("Kind of Blue", result?.collectorAlbums?.first()?.album?.name)
+    }
+
+    @Test
+    fun `findById retorna los artistas favoritos del coleccionista`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertEquals(1, result?.favoritePerformers?.size)
+        assertEquals("Rubén Blades Bellido de Luna", result?.favoritePerformers?.first()?.name)
+    }
+
+    @Test
+    fun `findById retorna null cuando el id no existe en la lista`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample, collectorSample2)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertNull(vm.findById(999))
+    }
+
+    @Test
+    fun `findById retorna null mientras la lista aun no ha cargado`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample)
+
+        val vm = CollectorViewModel(repo)
+        // NO llamamos advanceUntilIdle → la corutina de carga no ha terminado
+
+        assertNull(vm.findById(1))
+    }
+
+    @Test
+    fun `findById diferencia correctamente entre dos coleccionistas con ids distintos`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample, collectorSample2)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        val resultado1 = vm.findById(1)
+        val resultado2 = vm.findById(2)
+
+        assertEquals("Alejandro Vance", resultado1?.name)
+        assertEquals("Marcus Thorne", resultado2?.name)
+    }
+
+    @Test
+    fun `findById retorna coleccionista con descripcion correcta`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns listOf(collectorSample)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        val result = vm.findById(1)
+        assertNotNull(result)
+        assertEquals("Jazz collector", result?.description)
+    }
+}

--- a/app/src/test/java/com/uniandes/vinilos/ui/collectors/CollectorViewModelTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/collectors/CollectorViewModelTest.kt
@@ -6,16 +6,24 @@ import com.uniandes.vinilos.model.CollectorAlbum
 import com.uniandes.vinilos.repository.CollectorRepository
 import com.uniandes.vinilos.testing.MainDispatcherRule
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class CollectorViewModelTest {
@@ -27,91 +35,258 @@ class CollectorViewModelTest {
         id = 1, name = "Kind of Blue", cover = "", releaseDate = "1959",
         description = "Jazz", genre = "Jazz", recordLabel = "Columbia"
     )
-    private val collectorSample = Collector(
-        id = 1, name = "Alejandro Vance",
-        telephone = "3001234567", email = "alejandro@vinilos.com",
-        description = "Jazz collector",
-        collectorAlbums = listOf(CollectorAlbum(id = 1, price = 100, status = "NM", album = albumSample))
+
+    private val sample = listOf(
+        Collector(
+            id = 1, name = "Alejandro Vance",
+            telephone = "3001234567", email = "alejandro@vinilos.com",
+            description = "Jazz collector",
+            collectorAlbums = listOf(
+                CollectorAlbum(id = 1, price = 100, status = "NM", album = albumSample)
+            )
+        ),
+        Collector(id = 2, name = "Marcus Thorne", telephone = "3007654321", email = "marcus@vinilos.com"),
+        Collector(id = 3, name = "Sofia Reyes", telephone = "3009999999", email = "sofia@vinilos.com"),
+        Collector(id = 4, name = "Juan Pérez", telephone = "3001111111", email = "juan@vinilos.com"),
+        Collector(id = 5, name = "Ana Gómez", telephone = "3002222222", email = "ana@vinilos.com")
     )
-    private val collectorSample2 = Collector(
-        id = 2, name = "Marcus Thorne",
-        telephone = "3007654321", email = "marcus@vinilos.com"
-    )
+
+    // ── Carga inicial ──────────────────────────────────────────────────────────
 
     @Test
-    fun `loadCollectors carga la lista desde el repository`() = runTest {
+    fun `init carga collectors y actualiza el flow`() = runTest {
         val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } returns listOf(collectorSample, collectorSample2)
+        coEvery { repo.getCollectors() } returns sample
 
         val vm = CollectorViewModel(repo)
         advanceUntilIdle()
 
-        assertEquals(2, vm.collectors.value.size)
-        assertEquals("Alejandro Vance", vm.collectors.value[0].name)
+        assertEquals(5, vm.collectors.value.size)
+        assertFalse(vm.isLoading.value)
+        assertNull(vm.error.value)
+        coVerify(exactly = 1) { repo.getCollectors() }
     }
 
     @Test
-    fun `findById retorna el coleccionista correcto cuando existe en la lista`() = runTest {
+    fun `isLoading es false al terminar la carga`() = runTest {
         val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } returns listOf(collectorSample, collectorSample2)
+        coEvery { repo.getCollectors() } returns sample
 
         val vm = CollectorViewModel(repo)
         advanceUntilIdle()
 
-        val result = vm.findById(1)
-
-        assertNotNull(result)
-        assertEquals("Alejandro Vance", result?.name)
+        assertFalse(vm.isLoading.value)
     }
 
     @Test
-    fun `findById retorna los albums del coleccionista`() = runTest {
+    fun `IOException expone mensaje sin conexion`() = runTest {
         val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } returns listOf(collectorSample)
-
-        val vm = CollectorViewModel(repo)
-        advanceUntilIdle()
-
-        val result = vm.findById(1)
-
-        assertEquals(1, result?.collectorAlbums?.size)
-        assertEquals("Kind of Blue", result?.collectorAlbums?.first()?.album?.name)
-    }
-
-    @Test
-    fun `findById retorna null cuando el id no existe`() = runTest {
-        val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } returns listOf(collectorSample)
-
-        val vm = CollectorViewModel(repo)
-        advanceUntilIdle()
-
-        val result = vm.findById(999)
-
-        assertNull(result)
-    }
-
-    @Test
-    fun `findById retorna null mientras la lista aun no ha cargado`() = runTest {
-        val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } returns listOf(collectorSample)
-
-        val vm = CollectorViewModel(repo)
-
-        val result = vm.findById(1)
-
-        assertNull(result)
-    }
-
-    @Test
-    fun `loadCollectors guarda mensaje de error cuando el repository falla`() = runTest {
-        val repo = mockk<CollectorRepository>(relaxed = true)
-        coEvery { repo.getCollectors() } throws java.io.IOException("network down")
+        coEvery { repo.getCollectors() } throws IOException("offline")
 
         val vm = CollectorViewModel(repo)
         advanceUntilIdle()
 
         assertTrue(vm.collectors.value.isEmpty())
+        assertFalse(vm.isLoading.value)
+        assertEquals(
+            "Sin conexión. Revisa tu red e inténtalo de nuevo.",
+            vm.error.value
+        )
+    }
+
+    @Test
+    fun `HttpException expone el codigo HTTP`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(503, "".toResponseBody("application/json".toMediaTypeOrNull()))
+        )
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } throws httpError
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(
+            "El servidor respondió con un error (503).",
+            vm.error.value
+        )
+    }
+
+    // ── Paginación ─────────────────────────────────────────────────────────────
+
+    @Test
+    fun `visibleCollectors muestra solo la primera pagina inicialmente`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        // pageSize = 4, sample tiene 5
+        val visible = vm.visibleCollectors.first()
+        assertEquals(4, visible.size)
+    }
+
+    @Test
+    fun `hasMore es true cuando hay mas collectors que el pageSize`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample // 5 > pageSize(4)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertTrue(vm.hasMore.first())
+    }
+
+    @Test
+    fun `hasMore es false cuando los collectors caben en una pagina`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample.take(3) // 3 < pageSize(4)
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertFalse(vm.hasMore.first())
+    }
+
+    @Test
+    fun `loadMore incrementa los collectors visibles`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(4, vm.visibleCollectors.first().size)
+
+        vm.loadMore()
+
+        assertEquals(5, vm.visibleCollectors.first().size)
+    }
+
+    // ── Refresh ────────────────────────────────────────────────────────────────
+
+    @Test
+    fun `refreshCollectors actualiza la lista con datos nuevos`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        val extra = Collector(id = 6, name = "Nuevo Collector", telephone = "", email = "")
+        coEvery { repo.getCollectors() } returns sample
+        coEvery { repo.refreshCollectors() } returns sample + extra
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+        assertEquals(5, vm.collectors.value.size)
+
+        vm.refreshCollectors()
+        advanceUntilIdle()
+
+        assertEquals(6, vm.collectors.value.size)
+        coVerify(exactly = 1) { repo.refreshCollectors() }
+    }
+
+    @Test
+    fun `refreshCollectors limpia el error previo si tiene exito`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } throws IOException("offline")
+        coEvery { repo.refreshCollectors() } returns sample
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
         assertNotNull(vm.error.value)
+
+        vm.refreshCollectors()
+        advanceUntilIdle()
+
+        assertNull(vm.error.value)
+        assertEquals(5, vm.collectors.value.size)
+    }
+
+    @Test
+    fun `isRefreshing es true durante refresh y false al terminar`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample
+        coEvery { repo.refreshCollectors() } returns sample
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        assertFalse(vm.isRefreshing.value)
+
+        vm.refreshCollectors()
+        advanceUntilIdle()
+
+        assertFalse(vm.isRefreshing.value)
+    }
+
+    @Test
+    fun `refresh mantiene lista visible mientras actualiza`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        val extra = Collector(id = 6, name = "Nuevo Collector", telephone = "", email = "")
+        coEvery { repo.getCollectors() } returns sample
+        coEvery { repo.refreshCollectors() } returns sample + extra
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+        assertEquals(5, vm.collectors.value.size)
+
+        vm.refreshCollectors()
+
+        assertEquals(
+            "La lista anterior debe permanecer visible durante el refresh",
+            5, vm.collectors.value.size
+        )
+
+        advanceUntilIdle()
+        assertEquals(6, vm.collectors.value.size)
+    }
+
+    // ── loadCollector ──────────────────────────────────────────────────────────
+
+    @Test
+    fun `loadCollector agrega el coleccionista a collectors si no estaba`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns emptyList()
+        coEvery { repo.getCollector(99) } returns Collector(
+            id = 99, name = "Nuevo Collector",
+            telephone = "3009999999", email = "nuevo@vinilos.com"
+        )
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        vm.loadCollector(99)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.collectors.value.size)
+        assertEquals("Nuevo Collector", vm.collectors.value.first().name)
+    }
+
+    @Test
+    fun `loadCollector no llama al repository si el id ya existe en collectors`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns sample
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        vm.loadCollector(sample.first().id)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.getCollector(any()) }
+        assertEquals(5, vm.collectors.value.size)
+    }
+
+    @Test
+    fun `loadCollector no agrega nada si el repository devuelve null`() = runTest {
+        val repo = mockk<CollectorRepository>(relaxed = true)
+        coEvery { repo.getCollectors() } returns emptyList()
+        coEvery { repo.getCollector(99) } returns null
+
+        val vm = CollectorViewModel(repo)
+        advanceUntilIdle()
+
+        vm.loadCollector(99)
+        advanceUntilIdle()
+
+        assertTrue(vm.collectors.value.isEmpty())
     }
 }

--- a/kraken/features/collector_detail.feature
+++ b/kraken/features/collector_detail.feature
@@ -6,7 +6,7 @@ Feature: Detalle de coleccionista (HU06)
     Then I tap on element with accessibility id "nav_colecc."
     Then I wait
     Then I wait
-    Then I see the text "ARCHIVE DIRECTORY"
+    Then I see the text "DIRECTORIO DE"
     Then I tap on element with id "Manolo Bellon"
     Then I wait
     Then I wait
@@ -29,6 +29,6 @@ Feature: Detalle de coleccionista (HU06)
     Then I wait
     Then I tap on element with accessibility id "Volver"
     Then I wait
-    Then I see the text "ARCHIVE DIRECTORY"
+    Then I see the text "DIRECTORIO DE"
     Then I tap on element with accessibility id "nav_vinilos"
     Then I wait

--- a/kraken/features/collector_list.feature
+++ b/kraken/features/collector_list.feature
@@ -1,0 +1,42 @@
+Feature: Listado de coleccionistas (HU05)
+
+  @user1 @mobile
+  Scenario: Como usuario visitante navego al listado de coleccionistas y veo el contenido
+    Given I wait
+    Then I tap on element with accessibility id "nav_colecc."
+    Then I wait
+    Then I wait
+    Then I see the text "DIRECTORIO DE"
+    Then I see the text "Coleccionistas"
+    Then I see the text "encontrados"
+    Then I see the text "Manolo Bellon"
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait
+
+  @user2 @mobile
+  Scenario: Como usuario visitante busco un coleccionista por nombre y veo solo el resultado filtrado
+    Given I wait
+    Then I tap on element with accessibility id "nav_colecc."
+    Then I wait
+    Then I wait
+    Then I tap on element with accessibility id "collector_search"
+    Then I type "Manolo"
+    Then I wait
+    Then I see the text "Manolo Bellon"
+    Then I don't see the text "Jaime Monsalve"
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait
+
+  @user3 @mobile
+  Scenario: Como usuario visitante busco por artista favorito y veo el coleccionista correcto
+    Given I wait
+    Then I tap on element with accessibility id "nav_colecc."
+    Then I wait
+    Then I wait
+    Then I tap on element with accessibility id "collector_search"
+    Then I type "Queen"
+    Then I wait
+    Then I see the text "Jaime Monsalve"
+    Then I don't see the text "Manolo Bellon"
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait

--- a/kraken/features/mobile/step_definitions/step.js
+++ b/kraken/features/mobile/step_definitions/step.js
@@ -1,4 +1,5 @@
 const { Given, When, Then } = require("@cucumber/cucumber");
+const assert = require("assert");
 
 Then("I tap on element with id {string}", async function (text) {
   const element = await this.driver.$(
@@ -37,4 +38,16 @@ Then("I scroll down", async function () {
     direction: "down",
     percent: 3,
   });
+});
+
+Then("I don't see the text {string}", async function (text) {
+  const elements = await this.driver.$$(
+    `android=new UiSelector().textContains("${text}")`,
+  );
+  assert.strictEqual(elements.length, 0);
+});
+
+Then("I type {string}", async function (text) {
+  const element = await this.driver.$(`android=new UiSelector().focused(true)`);
+  await element.setValue(text);
 });


### PR DESCRIPTION
feature (hu05): listado de coleccionistas con datos reales, búsqueda y paginación

Implementa HU05 completa y corrige deuda técnica de HU06.

Cambios principales:
- CollectorListScreen conectada a datos reales via ViewModel
- Paginación con loadMore() igual que ArtistListScreen
- Buscador por nombre, email y artista favorito
- Header en español, avatar con inicial, artista favorito en cada item
- Colores de CollectorDetailScreen migrados a tokens de MaterialTheme
- loadCollector(id) en ViewModel + LaunchedEffect para carga directa al detalle
- Email en lugar de ID en CollectorDetailScreen
- Default value en viewModel para habilitar preview

Tests:
- CollectorRepositoryTest (9 casos)
- CollectorViewModelTest completo con paginación y refresh (12 casos)
- CollectorViewModelDetailTest (7 casos)
- CollectorListScreenInstrumentedTest (13 casos)
- Kraken: collector_list.feature (1 escenario), collector_detail.feature actualizado

README actualizado con todas las suites de tests