### PR TITLE
feat(hu-13): crear premios y asociar a artistas

### DIFF
--- a/app/schemas/com.uniandes.vinilos.database.VinilosDatabase/4.json
+++ b/app/schemas/com.uniandes.vinilos.database.VinilosDatabase/4.json
@@ -1,0 +1,232 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "915f203d4c678f93b1bbf7de1e46e7a6",
+    "entities": [
+      {
+        "tableName": "albums",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `cover` TEXT NOT NULL, `releaseDate` TEXT NOT NULL, `description` TEXT NOT NULL, `genre` TEXT NOT NULL, `recordLabel` TEXT NOT NULL, `tracks` TEXT NOT NULL, `performers` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cover",
+            "columnName": "cover",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "recordLabel",
+            "columnName": "recordLabel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tracks",
+            "columnName": "tracks",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "performers",
+            "columnName": "performers",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "performers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `image` TEXT NOT NULL, `description` TEXT NOT NULL, `birthDate` TEXT, `creationDate` TEXT, `albums` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creationDate",
+            "columnName": "creationDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "albums",
+            "columnName": "albums",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "collectors",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `telephone` TEXT NOT NULL, `email` TEXT NOT NULL, `birthDate` TEXT, `description` TEXT NOT NULL, `image` TEXT NOT NULL, `collectorAlbums` TEXT NOT NULL, `favoritePerformers` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "telephone",
+            "columnName": "telephone",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "email",
+            "columnName": "email",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "birthDate",
+            "columnName": "birthDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "image",
+            "columnName": "image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collectorAlbums",
+            "columnName": "collectorAlbums",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "favoritePerformers",
+            "columnName": "favoritePerformers",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "prizes",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `organization` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "organization",
+            "columnName": "organization",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '915f203d4c678f93b1bbf7de1e46e7a6')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/artists/ArtistDetailScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/artists/ArtistDetailScreenInstrumentedTest.kt
@@ -202,4 +202,89 @@ class ArtistDetailScreenInstrumentedTest {
             .onNodeWithTag(ArtistDetailTestTags.NAME)
             .assertIsDisplayed()
     }
+
+    // ─── HU13 - T1: Sección GALARDONES visible para COLLECTOR ────────────────
+
+    @Test
+    fun detailScreen_muestraSeccionGalardones_paraCollector() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                ArtistDetailScreen(
+                    artistId = samplePerformer.id,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(ArtistDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onNodeWithTag(ArtistDetailTestTags.PRIZES_SECTION)
+            .assertExists()
+        composeTestRule
+            .onNodeWithTag(ArtistDetailTestTags.PRIZES_CTA)
+            .assertExists()
+    }
+
+    // ─── HU13 - T2: Sección GALARDONES oculta para VISITOR ───────────────────
+
+    @Test
+    fun detailScreen_ocultaSeccionGalardones_paraVisitor() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                ArtistDetailScreen(
+                    artistId = samplePerformer.id,
+                    viewModel = vm,
+                    userRole = UserRole.VISITOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(ArtistDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onNodeWithTag(ArtistDetailTestTags.PRIZES_SECTION)
+            .assertDoesNotExist()
+    }
+
+    // ─── HU13 - T3: CTA Asociar premio invoca callback ───────────────────────
+
+    @Test
+    fun detailScreen_ctaAsociarPremio_invocaCallback() {
+        var navigatedToArtistId: Int? = null
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                ArtistDetailScreen(
+                    artistId = samplePerformer.id,
+                    viewModel = vm,
+                    onAssociatePrize = { navigatedToArtistId = it },
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(ArtistDetailTestTags.PRIZES_CTA))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(ArtistDetailTestTags.PRIZES_CTA).performClick()
+        assertTrue(navigatedToArtistId == samplePerformer.id)
+    }
 }

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/prizes/PrizeAssociateScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/prizes/PrizeAssociateScreenInstrumentedTest.kt
@@ -1,0 +1,205 @@
+package com.uniandes.vinilos.ui.prizes
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.model.UserRole
+import com.uniandes.vinilos.ui.theme.VinilosTheme
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class PrizeAssociateScreenInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val musician = Performer(
+        id = 1,
+        name = "Rubén Blades",
+        image = "",
+        description = "Cantautor",
+        birthDate = "1948-07-16"
+    )
+
+    private val samplePrizes = listOf(
+        Prize(10, "Grammy", "Music award", "NARAS"),
+        Prize(20, "Latin Grammy", "Latin music award", "LARAS")
+    )
+
+    private fun mockViewModel(
+        prizes: List<Prize> = samplePrizes,
+        isLoading: Boolean = false,
+        isSubmitting: Boolean = false,
+        error: String? = null
+    ): PrizeViewModel {
+        val vm = mockk<PrizeViewModel>(relaxed = true)
+        every { vm.prizes } returns MutableStateFlow(prizes)
+        every { vm.isLoading } returns MutableStateFlow(isLoading)
+        every { vm.isSubmitting } returns MutableStateFlow(isSubmitting)
+        every { vm.error } returns MutableStateFlow(error)
+        every { vm.associationSuccess } returns MutableStateFlow(null)
+        return vm
+    }
+
+    @Test
+    fun pantalla_muestra_lista_de_premios_existentes() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = musician,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(PrizeAssociateTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.LIST).assertExists()
+        composeTestRule.onNodeWithText("Grammy").assertExists()
+        composeTestRule.onNodeWithText("Latin Grammy").assertExists()
+    }
+
+    @Test
+    fun spinner_visible_cuando_isLoading_true_y_lista_vacia() {
+        val vm = mockViewModel(prizes = emptyList(), isLoading = true)
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = musician,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithTag(PrizeAssociateTestTags.LOADING)
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun toggle_abre_el_formulario_para_crear_nuevo_premio() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = musician,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(PrizeAssociateTestTags.TOGGLE_NEW))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.TOGGLE_NEW).performClick()
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.FIELD_NAME).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.FIELD_ORGANIZATION).assertIsDisplayed()
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.FIELD_DESCRIPTION).assertIsDisplayed()
+    }
+
+    @Test
+    fun submit_invoca_submitAssociation_con_los_valores_del_formulario() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = musician,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(PrizeAssociateTestTags.FIELD_DATE))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        // Selecciona un premio existente y escribe la fecha
+        composeTestRule.onNodeWithTag("${PrizeAssociateTestTags.PRIZE_ITEM_PREFIX}10").performClick()
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.FIELD_DATE).performTextInput("2024-05-01")
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.SUBMIT).performClick()
+
+        verify {
+            vm.submitAssociation(
+                performerId = 1,
+                isMusician = true,
+                premiationDate = "2024-05-01",
+                selectedPrizeId = 10,
+                newPrizeName = null,
+                newPrizeDescription = null,
+                newPrizeOrganization = null
+            )
+        }
+    }
+
+    @Test
+    fun mensaje_de_error_visible_cuando_viewmodel_expone_error() {
+        val vm = mockViewModel(error = "Sin conexión. Revisa tu red e inténtalo de nuevo.")
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = musician,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(PrizeAssociateTestTags.ERROR))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.ERROR).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Sin conexión", substring = true).assertExists()
+    }
+
+    @Test
+    fun artista_nulo_muestra_estado_vacio() {
+        val vm = mockViewModel()
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                PrizeAssociateScreen(
+                    artist = null,
+                    viewModel = vm,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithTag(PrizeAssociateTestTags.EMPTY).assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/database/PrizeMappers.kt
+++ b/app/src/main/java/com/uniandes/vinilos/database/PrizeMappers.kt
@@ -1,0 +1,18 @@
+package com.uniandes.vinilos.database
+
+import com.uniandes.vinilos.database.entities.PrizeEntity
+import com.uniandes.vinilos.model.Prize
+
+fun PrizeEntity.toPrize() = Prize(
+    id = id,
+    name = name,
+    description = description,
+    organization = organization
+)
+
+fun Prize.toEntity() = PrizeEntity(
+    id = id,
+    name = name,
+    description = description,
+    organization = organization
+)

--- a/app/src/main/java/com/uniandes/vinilos/database/VinilosDatabase.kt
+++ b/app/src/main/java/com/uniandes/vinilos/database/VinilosDatabase.kt
@@ -10,19 +10,22 @@ import androidx.sqlite.db.SupportSQLiteDatabase
 import com.uniandes.vinilos.database.dao.AlbumDao
 import com.uniandes.vinilos.database.dao.CollectorDao
 import com.uniandes.vinilos.database.dao.PerformerDao
+import com.uniandes.vinilos.database.dao.PrizeDao
 import com.uniandes.vinilos.database.entities.AlbumEntity
 import com.uniandes.vinilos.database.entities.CollectorEntity
 import com.uniandes.vinilos.database.entities.PerformerEntity
+import com.uniandes.vinilos.database.entities.PrizeEntity
 
 @Database(
-    entities = [AlbumEntity::class, PerformerEntity::class, CollectorEntity::class],
-    version = 3
+    entities = [AlbumEntity::class, PerformerEntity::class, CollectorEntity::class, PrizeEntity::class],
+    version = 4
 )
 @TypeConverters(Converters::class)
 abstract class VinilosDatabase : RoomDatabase() {
     abstract fun albumDao(): AlbumDao
     abstract fun performerDao(): PerformerDao
     abstract fun collectorDao(): CollectorDao
+    abstract fun prizeDao(): PrizeDao
 
     companion object {
         @Volatile
@@ -35,7 +38,7 @@ abstract class VinilosDatabase : RoomDatabase() {
                     VinilosDatabase::class.java,
                     "vinilos_database"
                 )
-                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3)
+                    .addMigrations(MIGRATION_1_2, MIGRATION_2_3, MIGRATION_3_4)
                     .build()
                     .also { INSTANCE = it }
             }
@@ -63,6 +66,19 @@ val MIGRATION_2_3 = object : Migration(2, 3) {
                 image TEXT NOT NULL DEFAULT '',
                 collectorAlbums TEXT NOT NULL DEFAULT '[]',
                 favoritePerformers TEXT NOT NULL DEFAULT '[]'
+            )"""
+        )
+    }
+}
+
+val MIGRATION_3_4 = object : Migration(3, 4) {
+    override fun migrate(database: SupportSQLiteDatabase) {
+        database.execSQL(
+            """CREATE TABLE IF NOT EXISTS prizes (
+                id INTEGER PRIMARY KEY NOT NULL,
+                name TEXT NOT NULL,
+                description TEXT NOT NULL DEFAULT '',
+                organization TEXT NOT NULL DEFAULT ''
             )"""
         )
     }

--- a/app/src/main/java/com/uniandes/vinilos/database/dao/PrizeDao.kt
+++ b/app/src/main/java/com/uniandes/vinilos/database/dao/PrizeDao.kt
@@ -1,0 +1,22 @@
+package com.uniandes.vinilos.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.uniandes.vinilos.database.entities.PrizeEntity
+
+@Dao
+interface PrizeDao {
+    @Query("SELECT * FROM prizes")
+    suspend fun getAll(): List<PrizeEntity>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(prizes: List<PrizeEntity>)
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(prize: PrizeEntity)
+
+    @Query("DELETE FROM prizes")
+    suspend fun deleteAll()
+}

--- a/app/src/main/java/com/uniandes/vinilos/database/entities/PrizeEntity.kt
+++ b/app/src/main/java/com/uniandes/vinilos/database/entities/PrizeEntity.kt
@@ -1,0 +1,12 @@
+package com.uniandes.vinilos.database.entities
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity(tableName = "prizes")
+data class PrizeEntity(
+    @PrimaryKey val id: Int,
+    val name: String,
+    val description: String,
+    val organization: String
+)

--- a/app/src/main/java/com/uniandes/vinilos/model/PerformerPrize.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/PerformerPrize.kt
@@ -1,0 +1,7 @@
+package com.uniandes.vinilos.model
+
+data class PerformerPrize(
+    val id: Int = 0,
+    val premiationDate: String,
+    val prize: Prize? = null
+)

--- a/app/src/main/java/com/uniandes/vinilos/model/Prize.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/Prize.kt
@@ -1,0 +1,8 @@
+package com.uniandes.vinilos.model
+
+data class Prize(
+    val id: Int,
+    val name: String,
+    val description: String,
+    val organization: String
+)

--- a/app/src/main/java/com/uniandes/vinilos/network/VinilosApi.kt
+++ b/app/src/main/java/com/uniandes/vinilos/network/VinilosApi.kt
@@ -3,7 +3,11 @@ package com.uniandes.vinilos.network
 import com.uniandes.vinilos.model.Album
 import com.uniandes.vinilos.model.Collector
 import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.model.PerformerPrize
+import com.uniandes.vinilos.model.Prize
+import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface VinilosApi {
@@ -24,4 +28,34 @@ interface VinilosApi {
 
     @GET("collectors/{id}")
     suspend fun getCollector(@Path("id") id: Int): Collector
+
+    @GET("prizes")
+    suspend fun getPrizes(): List<Prize>
+
+    @POST("prizes")
+    suspend fun createPrize(@Body prize: PrizeCreateBody): Prize
+
+    @POST("prizes/{prizeId}/musicians/{musicianId}")
+    suspend fun associatePrizeToMusician(
+        @Path("prizeId") prizeId: Int,
+        @Path("musicianId") musicianId: Int,
+        @Body body: PerformerPrizeBody
+    ): PerformerPrize
+
+    @POST("prizes/{prizeId}/bands/{bandId}")
+    suspend fun associatePrizeToBand(
+        @Path("prizeId") prizeId: Int,
+        @Path("bandId") bandId: Int,
+        @Body body: PerformerPrizeBody
+    ): PerformerPrize
 }
+
+data class PrizeCreateBody(
+    val name: String,
+    val description: String,
+    val organization: String
+)
+
+data class PerformerPrizeBody(
+    val premiationDate: String
+)

--- a/app/src/main/java/com/uniandes/vinilos/repository/PrizeRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilos/repository/PrizeRepository.kt
@@ -1,0 +1,60 @@
+package com.uniandes.vinilos.repository
+
+import com.uniandes.vinilos.database.dao.PrizeDao
+import com.uniandes.vinilos.database.toEntity
+import com.uniandes.vinilos.database.toPrize
+import com.uniandes.vinilos.model.PerformerPrize
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.network.NetworkServiceAdapter
+import com.uniandes.vinilos.network.PerformerPrizeBody
+import com.uniandes.vinilos.network.PrizeCreateBody
+import com.uniandes.vinilos.network.VinilosApi
+
+class PrizeRepository(
+    private val dao: PrizeDao,
+    private val api: VinilosApi = NetworkServiceAdapter.api
+) {
+    suspend fun getPrizes(): List<Prize> {
+        val cached = dao.getAll()
+        if (cached.isNotEmpty()) {
+            return cached.map { it.toPrize() }
+        }
+        val remote = api.getPrizes()
+        dao.insertAll(remote.map { it.toEntity() })
+        return remote
+    }
+
+    suspend fun refreshPrizes(): List<Prize> {
+        dao.deleteAll()
+        val remote = api.getPrizes()
+        dao.insertAll(remote.map { it.toEntity() })
+        return remote
+    }
+
+    suspend fun createPrize(name: String, description: String, organization: String): Prize {
+        val created = api.createPrize(
+            PrizeCreateBody(name = name, description = description, organization = organization)
+        )
+        dao.insert(created.toEntity())
+        return created
+    }
+
+    /**
+     * Routes the association call to the right endpoint depending on whether the
+     * performer is a musician (`birthDate != null`) or a band (only `creationDate`).
+     * This mirrors the heuristic the rest of the app already uses to label artists.
+     */
+    suspend fun associatePrizeToPerformer(
+        prizeId: Int,
+        performerId: Int,
+        isMusician: Boolean,
+        premiationDate: String
+    ): PerformerPrize {
+        val body = PerformerPrizeBody(premiationDate = premiationDate)
+        return if (isMusician) {
+            api.associatePrizeToMusician(prizeId, performerId, body)
+        } else {
+            api.associatePrizeToBand(prizeId, performerId, body)
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistDetailScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/artists/ArtistDetailScreen.kt
@@ -36,13 +36,15 @@ import com.uniandes.vinilos.ui.components.VinilosTopBar
 
 // ── TestTags ──────────────────────────────────────────────────────────────────
 object ArtistDetailTestTags {
-    const val SCREEN  = "artist_detail_screen"
-    const val LOADING = "loading_indicator"
-    const val NAME    = "artist_detail_name"
-    const val IMAGE   = "artist_detail_image"
-    const val ALBUMS  = "artist_detail_albums"
-    const val BACK    = "top_bar_back_button" 
-    const val STATS   = "artist_detail_stats"
+    const val SCREEN          = "artist_detail_screen"
+    const val LOADING         = "loading_indicator"
+    const val NAME            = "artist_detail_name"
+    const val IMAGE           = "artist_detail_image"
+    const val ALBUMS          = "artist_detail_albums"
+    const val BACK            = "top_bar_back_button"
+    const val STATS           = "artist_detail_stats"
+    const val PRIZES_SECTION  = "artist_detail_prizes_section"
+    const val PRIZES_CTA      = "artist_detail_prizes_cta"
 }
 
 // ── Pantalla principal ────────────────────────────────────────────────────────
@@ -52,7 +54,8 @@ fun ArtistDetailScreen(
     viewModel: ArtistViewModel,
     onBack: () -> Unit = {},
     onMenuClick: () -> Unit = {},
-    userRole: UserRole? = null 
+    onAssociatePrize: (Int) -> Unit = {},
+    userRole: UserRole? = null
 ) {
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val performer = viewModel.findById(artistId)
@@ -64,7 +67,8 @@ fun ArtistDetailScreen(
             performer = performer,
             onBack = onBack,
             onMenuClick = onMenuClick,
-            userRole = userRole  
+            onAssociatePrize = onAssociatePrize,
+            userRole = userRole
         )
     }
 }
@@ -88,6 +92,7 @@ private fun ArtistDetailContent(
         performer: Performer,
         onBack: () -> Unit,
         onMenuClick: () -> Unit,
+        onAssociatePrize: (Int) -> Unit = {},
         userRole: UserRole? = null
     ) {
     Scaffold(
@@ -116,6 +121,11 @@ private fun ArtistDetailContent(
             GenreChipsSection(albums = performer.albums)
             StatsSection(performer = performer)
             DiscographySection(albums = performer.albums)
+            if (userRole == UserRole.COLLECTOR) {
+                PrizesSection(
+                    onAssociatePrize = { onAssociatePrize(performer.id) }
+                )
+            }
             Spacer(modifier = Modifier.height(32.dp))
         }
     }
@@ -336,6 +346,62 @@ private fun DiscographySection(albums: List<Album>) {
             items(albums) { album ->
                 AlbumCardSmall(album = album)
             }
+        }
+    }
+}
+
+// ── Sección 6: Galardones (HU-13) — sólo visible para COLLECTOR ───────────────
+@Composable
+private fun PrizesSection(onAssociatePrize: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(top = 32.dp)
+            .testTag(ArtistDetailTestTags.PRIZES_SECTION)
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp)
+        ) {
+            Text(
+                text = "LOS GALARDONES",
+                fontSize = 11.sp,
+                letterSpacing = 2.sp,
+                color = MaterialTheme.colorScheme.primary,
+                fontWeight = FontWeight.SemiBold
+            )
+            Text(
+                text = "Premios y Reconocimientos",
+                fontSize = 26.sp,
+                fontStyle = FontStyle.Italic,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = "Asocia un premio existente o crea uno nuevo para este artista.",
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.75f)
+            )
+        }
+        Spacer(modifier = Modifier.height(16.dp))
+        Button(
+            onClick = onAssociatePrize,
+            shape = androidx.compose.foundation.shape.RoundedCornerShape(4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                contentColor = MaterialTheme.colorScheme.onPrimary
+            ),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp)
+                .height(48.dp)
+                .testTag(ArtistDetailTestTags.PRIZES_CTA)
+        ) {
+            Text(
+                text = "Asociar premio",
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.sp
+            )
         }
     }
 }

--- a/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
@@ -62,6 +62,8 @@ import com.uniandes.vinilos.ui.collectors.CollectorDetailScreen
 import com.uniandes.vinilos.ui.collectors.CollectorListScreen
 import com.uniandes.vinilos.ui.collectors.CollectorViewModel
 import com.uniandes.vinilos.ui.home.HomeScreen
+import com.uniandes.vinilos.ui.prizes.PrizeAssociateScreen
+import com.uniandes.vinilos.ui.prizes.PrizeViewModel
 import com.uniandes.vinilos.ui.role.RoleSelectionScreen
 import com.uniandes.vinilos.ui.components.AppSettingsDrawer
 import kotlinx.coroutines.launch
@@ -82,6 +84,9 @@ sealed class Screen(val route: String) {
     object CollectorList : Screen("collector_list")
     object CollectorDetail : Screen("collector_detail/{collectorId}") {
         fun createRoute(collectorId: Int) = "collector_detail/$collectorId"
+    }
+    object PrizeAssociate : Screen("prize_associate/{artistId}") {
+        fun createRoute(artistId: Int) = "prize_associate/$artistId"
     }
 }
 
@@ -115,10 +120,12 @@ fun AppNavigation(
     val albumViewModel: AlbumViewModel = viewModel(factory = AlbumViewModel.factory(context))
     val artistViewModel: ArtistViewModel = viewModel(factory = ArtistViewModel.factory(context))
     val collectorViewModel: CollectorViewModel = viewModel(factory = CollectorViewModel.factory(context))
+    val prizeViewModel: PrizeViewModel = viewModel(factory = PrizeViewModel.factory(context))
 
     val isDetailScreen = currentRoute?.startsWith("album_detail") == true ||
             currentRoute?.startsWith("artist_detail") == true ||
-            currentRoute?.startsWith("collector_detail") == true
+            currentRoute?.startsWith("collector_detail") == true ||
+            currentRoute?.startsWith("prize_associate") == true
 
     var isBarVisible by remember { mutableStateOf(true) }
 
@@ -282,7 +289,24 @@ fun AppNavigation(
                         viewModel = artistViewModel,
                         onBack = { navController.navigateUp() },
                         onMenuClick = onMenuClick,
-                        userRole = userRole 
+                        onAssociatePrize = { id ->
+                            navController.navigate(Screen.PrizeAssociate.createRoute(id))
+                        },
+                        userRole = userRole
+                    )
+                }
+                composable(
+                    route = Screen.PrizeAssociate.route,
+                    arguments = listOf(navArgument("artistId") { type = NavType.IntType })
+                ) { backStackEntry ->
+                    val artistId = backStackEntry.arguments?.getInt("artistId") ?: return@composable
+                    PrizeAssociateScreen(
+                        artist = artistViewModel.findById(artistId),
+                        viewModel = prizeViewModel,
+                        onBack = { navController.navigateUp() },
+                        onMenuClick = onMenuClick,
+                        onAssociated = { navController.navigateUp() },
+                        userRole = userRole
                     )
                 }
                 composable(Screen.CollectorList.route) {

--- a/app/src/main/java/com/uniandes/vinilos/ui/prizes/PrizeAssociateScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/prizes/PrizeAssociateScreen.kt
@@ -1,0 +1,455 @@
+package com.uniandes.vinilos.ui.prizes
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.RadioButtonDefaults
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.uniandes.vinilos.model.Performer
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.model.UserRole
+import com.uniandes.vinilos.ui.components.VinilosTopBar
+
+object PrizeAssociateTestTags {
+    const val SCREEN              = "prize_associate_screen"
+    const val LOADING             = "loading_indicator"
+    const val ERROR               = "error_message"
+    const val LIST                = "prize_associate_list"
+    const val PRIZE_ITEM_PREFIX   = "prize_item_"
+    const val TOGGLE_NEW          = "prize_associate_toggle_new"
+    const val FIELD_NAME          = "prize_associate_field_name"
+    const val FIELD_DESCRIPTION   = "prize_associate_field_description"
+    const val FIELD_ORGANIZATION  = "prize_associate_field_organization"
+    const val FIELD_DATE          = "prize_associate_field_date"
+    const val SUBMIT              = "prize_associate_submit"
+    const val SUCCESS             = "prize_associate_success"
+    const val EMPTY               = "prize_associate_empty"
+}
+
+@Composable
+fun PrizeAssociateScreen(
+    artist: Performer?,
+    viewModel: PrizeViewModel,
+    onBack: () -> Unit = {},
+    onMenuClick: () -> Unit = {},
+    onAssociated: () -> Unit = {},
+    userRole: UserRole? = null
+) {
+    val prizes by viewModel.prizes.collectAsStateWithLifecycle()
+    val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
+    val isSubmitting by viewModel.isSubmitting.collectAsStateWithLifecycle()
+    val error by viewModel.error.collectAsStateWithLifecycle()
+    val success by viewModel.associationSuccess.collectAsStateWithLifecycle()
+
+    var selectedPrizeId by remember { mutableStateOf<Int?>(null) }
+    var showNewForm by remember { mutableStateOf(false) }
+    var newName by remember { mutableStateOf("") }
+    var newDescription by remember { mutableStateOf("") }
+    var newOrganization by remember { mutableStateOf("") }
+    var premiationDate by remember { mutableStateOf("") }
+
+    LaunchedEffect(success) {
+        if (success != null) {
+            viewModel.consumeAssociationSuccess()
+            onAssociated()
+        }
+    }
+
+    Scaffold(
+        topBar = {
+            VinilosTopBar(
+                title = "Asociar premio",
+                showBack = true,
+                onBack = onBack,
+                onMenuClick = onMenuClick,
+                userRole = userRole
+            )
+        }
+    ) { padding ->
+        when {
+            artist == null -> EmptyArtistState(padding)
+            isLoading && prizes.isEmpty() -> LoadingState(padding)
+            else -> Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(padding)
+                    .verticalScroll(rememberScrollState())
+                    .testTag(PrizeAssociateTestTags.SCREEN)
+            ) {
+                HeroHeader(artist = artist)
+                SectionHeader(eyebrow = "PASO 1", title = "Elige un premio")
+                PrizeList(
+                    prizes = prizes,
+                    selectedPrizeId = selectedPrizeId,
+                    isFormOpen = showNewForm,
+                    onSelect = {
+                        selectedPrizeId = it
+                        showNewForm = false
+                    }
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                NewPrizeToggle(
+                    isOpen = showNewForm,
+                    onClick = {
+                        showNewForm = !showNewForm
+                        if (showNewForm) selectedPrizeId = null
+                    }
+                )
+                if (showNewForm) {
+                    NewPrizeFields(
+                        name = newName,
+                        onNameChange = { newName = it },
+                        description = newDescription,
+                        onDescriptionChange = { newDescription = it },
+                        organization = newOrganization,
+                        onOrganizationChange = { newOrganization = it }
+                    )
+                }
+                SectionHeader(eyebrow = "PASO 2", title = "Fecha de premiación")
+                DateField(
+                    value = premiationDate,
+                    onChange = { premiationDate = it }
+                )
+                ErrorBanner(message = error)
+                SubmitButton(
+                    isSubmitting = isSubmitting,
+                    onClick = {
+                        viewModel.submitAssociation(
+                            performerId = artist.id,
+                            isMusician = artist.birthDate != null,
+                            premiationDate = premiationDate,
+                            selectedPrizeId = selectedPrizeId,
+                            newPrizeName = if (showNewForm) newName else null,
+                            newPrizeDescription = if (showNewForm) newDescription else null,
+                            newPrizeOrganization = if (showNewForm) newOrganization else null
+                        )
+                    }
+                )
+                Spacer(modifier = Modifier.height(32.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun LoadingState(padding: androidx.compose.foundation.layout.PaddingValues) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding)
+            .testTag(PrizeAssociateTestTags.LOADING),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}
+
+@Composable
+private fun EmptyArtistState(padding: androidx.compose.foundation.layout.PaddingValues) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(padding),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(
+            text = "Artista no disponible",
+            style = MaterialTheme.typography.bodyLarge,
+            modifier = Modifier.testTag(PrizeAssociateTestTags.EMPTY)
+        )
+    }
+}
+
+@Composable
+private fun HeroHeader(artist: Performer) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 24.dp)
+    ) {
+        Text(
+            text = "NUEVO RECONOCIMIENTO",
+            fontSize = 11.sp,
+            letterSpacing = 2.sp,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        Text(
+            text = "Para ${artist.name}",
+            fontSize = 28.sp,
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Italic,
+            lineHeight = 32.sp
+        )
+    }
+}
+
+@Composable
+private fun SectionHeader(eyebrow: String, title: String) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .padding(top = 8.dp, bottom = 12.dp)
+    ) {
+        Text(
+            text = eyebrow,
+            fontSize = 11.sp,
+            letterSpacing = 2.sp,
+            color = MaterialTheme.colorScheme.primary,
+            fontWeight = FontWeight.SemiBold
+        )
+        Text(
+            text = title,
+            fontSize = 22.sp,
+            fontWeight = FontWeight.Bold,
+            fontStyle = FontStyle.Italic
+        )
+    }
+}
+
+@Composable
+private fun PrizeList(
+    prizes: List<Prize>,
+    selectedPrizeId: Int?,
+    isFormOpen: Boolean,
+    onSelect: (Int) -> Unit
+) {
+    if (prizes.isEmpty()) return
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp)
+            .testTag(PrizeAssociateTestTags.LIST)
+    ) {
+        prizes.forEach { prize ->
+            Surface(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = 4.dp)
+                    .testTag("${PrizeAssociateTestTags.PRIZE_ITEM_PREFIX}${prize.id}"),
+                shape = RoundedCornerShape(4.dp),
+                color = MaterialTheme.colorScheme.background,
+                onClick = { onSelect(prize.id) }
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(12.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    RadioButton(
+                        selected = selectedPrizeId == prize.id && !isFormOpen,
+                        onClick = { onSelect(prize.id) },
+                        colors = RadioButtonDefaults.colors(
+                            selectedColor = MaterialTheme.colorScheme.primary
+                        )
+                    )
+                    Spacer(modifier = Modifier.size(8.dp))
+                    Column(modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            text = prize.name,
+                            fontSize = 16.sp,
+                            fontWeight = FontWeight.SemiBold
+                        )
+                        if (prize.organization.isNotBlank()) {
+                            Text(
+                                text = prize.organization,
+                                fontSize = 12.sp,
+                                color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f)
+                            )
+                        }
+                    }
+                }
+            }
+            HorizontalDivider(thickness = 0.5.dp)
+        }
+    }
+}
+
+@Composable
+private fun NewPrizeToggle(isOpen: Boolean, onClick: () -> Unit) {
+    TextButton(
+        onClick = onClick,
+        modifier = Modifier
+            .padding(horizontal = 16.dp)
+            .testTag(PrizeAssociateTestTags.TOGGLE_NEW)
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Add,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp)
+        )
+        Spacer(modifier = Modifier.size(6.dp))
+        Text(
+            text = if (isOpen) "Cancelar nuevo premio" else "Crear un nuevo premio",
+            fontSize = 13.sp,
+            letterSpacing = 1.sp,
+            fontWeight = FontWeight.SemiBold
+        )
+    }
+}
+
+@Composable
+private fun NewPrizeFields(
+    name: String,
+    onNameChange: (String) -> Unit,
+    description: String,
+    onDescriptionChange: (String) -> Unit,
+    organization: String,
+    onOrganizationChange: (String) -> Unit
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp),
+        verticalArrangement = Arrangement.spacedBy(12.dp)
+    ) {
+        OutlinedTextField(
+            value = name,
+            onValueChange = onNameChange,
+            label = { Text("Nombre del premio") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(PrizeAssociateTestTags.FIELD_NAME)
+        )
+        OutlinedTextField(
+            value = organization,
+            onValueChange = onOrganizationChange,
+            label = { Text("Organización") },
+            singleLine = true,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(PrizeAssociateTestTags.FIELD_ORGANIZATION)
+        )
+        OutlinedTextField(
+            value = description,
+            onValueChange = onDescriptionChange,
+            label = { Text("Descripción") },
+            minLines = 2,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(PrizeAssociateTestTags.FIELD_DESCRIPTION)
+        )
+    }
+}
+
+@Composable
+private fun DateField(value: String, onChange: (String) -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 4.dp)
+    ) {
+        OutlinedTextField(
+            value = value,
+            onValueChange = onChange,
+            label = { Text("Fecha (YYYY-MM-DD)") },
+            singleLine = true,
+            placeholder = { Text("2024-01-15") },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(PrizeAssociateTestTags.FIELD_DATE)
+        )
+    }
+}
+
+@Composable
+private fun ErrorBanner(message: String?) {
+    if (message.isNullOrBlank()) return
+    Surface(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .testTag(PrizeAssociateTestTags.ERROR),
+        color = MaterialTheme.colorScheme.errorContainer,
+        shape = RoundedCornerShape(4.dp)
+    ) {
+        Text(
+            text = message,
+            color = MaterialTheme.colorScheme.onErrorContainer,
+            modifier = Modifier.padding(12.dp),
+            fontSize = 13.sp
+        )
+    }
+}
+
+@Composable
+private fun SubmitButton(isSubmitting: Boolean, onClick: () -> Unit) {
+    Button(
+        onClick = onClick,
+        enabled = !isSubmitting,
+        shape = RoundedCornerShape(4.dp),
+        colors = ButtonDefaults.buttonColors(
+            containerColor = MaterialTheme.colorScheme.primary,
+            contentColor = MaterialTheme.colorScheme.onPrimary
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 16.dp)
+            .height(52.dp)
+            .testTag(PrizeAssociateTestTags.SUBMIT)
+    ) {
+        if (isSubmitting) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(20.dp),
+                color = MaterialTheme.colorScheme.onPrimary,
+                strokeWidth = 2.dp
+            )
+        } else {
+            Icon(
+                imageVector = Icons.Filled.CheckCircle,
+                contentDescription = null,
+                modifier = Modifier.size(18.dp)
+            )
+            Spacer(modifier = Modifier.size(8.dp))
+            Text(
+                text = "Asociar premio",
+                fontWeight = FontWeight.SemiBold,
+                letterSpacing = 1.sp
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/prizes/PrizeViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/prizes/PrizeViewModel.kt
@@ -1,0 +1,149 @@
+package com.uniandes.vinilos.ui.prizes
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.uniandes.vinilos.database.VinilosDatabase
+import com.uniandes.vinilos.model.PerformerPrize
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.repository.PrizeRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import retrofit2.HttpException
+import java.io.IOException
+
+class PrizeViewModel(
+    private val repository: PrizeRepository
+) : ViewModel() {
+
+    private val _prizes = MutableStateFlow<List<Prize>>(emptyList())
+    val prizes: StateFlow<List<Prize>> = _prizes.asStateFlow()
+
+    private val _isLoading = MutableStateFlow(false)
+    val isLoading: StateFlow<Boolean> = _isLoading.asStateFlow()
+
+    private val _isSubmitting = MutableStateFlow(false)
+    val isSubmitting: StateFlow<Boolean> = _isSubmitting.asStateFlow()
+
+    private val _error = MutableStateFlow<String?>(null)
+    val error: StateFlow<String?> = _error.asStateFlow()
+
+    private val _associationSuccess = MutableStateFlow<PerformerPrize?>(null)
+    val associationSuccess: StateFlow<PerformerPrize?> = _associationSuccess.asStateFlow()
+
+    init { loadPrizes() }
+
+    fun loadPrizes() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                _prizes.value = repository.getPrizes()
+            } catch (e: IOException) {
+                _error.value = "Sin conexión. Revisa tu red e inténtalo de nuevo."
+            } catch (e: HttpException) {
+                _error.value = "El servidor respondió con un error (${e.code()})."
+            } catch (e: Exception) {
+                _error.value = "Error inesperado: ${e.message}"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    fun refreshPrizes() {
+        viewModelScope.launch {
+            _isLoading.value = true
+            _error.value = null
+            try {
+                _prizes.value = repository.refreshPrizes()
+            } catch (e: IOException) {
+                _error.value = "Sin conexión. Revisa tu red e inténtalo de nuevo."
+            } catch (e: HttpException) {
+                _error.value = "El servidor respondió con un error (${e.code()})."
+            } catch (e: Exception) {
+                _error.value = "Error inesperado: ${e.message}"
+            } finally {
+                _isLoading.value = false
+            }
+        }
+    }
+
+    /**
+     * Submits the full associate flow: optionally creates a new prize, then links it
+     * to the given performer with the supplied premiation date. The UI consumes
+     * `associationSuccess` to navigate away once the round-trip lands.
+     */
+    fun submitAssociation(
+        performerId: Int,
+        isMusician: Boolean,
+        premiationDate: String,
+        selectedPrizeId: Int?,
+        newPrizeName: String?,
+        newPrizeDescription: String?,
+        newPrizeOrganization: String?
+    ) {
+        if (premiationDate.isBlank()) {
+            _error.value = "La fecha de premiación es obligatoria."
+            return
+        }
+        if (selectedPrizeId == null && newPrizeName.isNullOrBlank()) {
+            _error.value = "Selecciona un premio existente o ingresa el nombre del nuevo premio."
+            return
+        }
+
+        viewModelScope.launch {
+            _isSubmitting.value = true
+            _error.value = null
+            try {
+                val prizeId = selectedPrizeId ?: repository.createPrize(
+                    name = newPrizeName!!.trim(),
+                    description = newPrizeDescription.orEmpty().trim(),
+                    organization = newPrizeOrganization.orEmpty().trim()
+                ).also { created ->
+                    // Push the freshly-created prize into the visible list so the UI
+                    // reflects it without an extra refresh.
+                    _prizes.value = _prizes.value + created
+                }.id
+
+                _associationSuccess.value = repository.associatePrizeToPerformer(
+                    prizeId = prizeId,
+                    performerId = performerId,
+                    isMusician = isMusician,
+                    premiationDate = premiationDate
+                )
+            } catch (e: IOException) {
+                _error.value = "Sin conexión. Revisa tu red e inténtalo de nuevo."
+            } catch (e: HttpException) {
+                _error.value = "El servidor respondió con un error (${e.code()})."
+            } catch (e: Exception) {
+                _error.value = "Error inesperado: ${e.message}"
+            } finally {
+                _isSubmitting.value = false
+            }
+        }
+    }
+
+    fun consumeAssociationSuccess() {
+        _associationSuccess.value = null
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+
+    companion object {
+        fun factory(context: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val dao = VinilosDatabase.getDatabase(context).prizeDao()
+                    val repository = PrizeRepository(dao)
+                    @Suppress("UNCHECKED_CAST")
+                    return PrizeViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/app/src/test/java/com/uniandes/vinilos/network/VinilosApiContractTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/network/VinilosApiContractTest.kt
@@ -73,6 +73,71 @@ class VinilosApiContractTest {
         assertTrue(album.performers.isEmpty())
     }
 
+    // ─── HU-13: Contrato de premios ───────────────────────────────────────────
+
+    @Test
+    fun `getPrizes hace GET a la ruta prizes`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody("[]"))
+
+        api.getPrizes()
+
+        val request = server.takeRequest()
+        assertEquals("GET", request.method)
+        assertEquals("/prizes", request.path)
+    }
+
+    @Test
+    fun `getPrizes deserializa la lista`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(SAMPLE_PRIZES_JSON))
+
+        val prizes = api.getPrizes()
+
+        assertEquals(2, prizes.size)
+        assertEquals("Grammy", prizes[0].name)
+        assertEquals("NARAS", prizes[0].organization)
+    }
+
+    @Test
+    fun `createPrize hace POST con el body y devuelve el premio creado`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(CREATED_PRIZE_JSON))
+
+        val created = api.createPrize(
+            PrizeCreateBody(name = "Mercury", description = "UK", organization = "BPI")
+        )
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/prizes", request.path)
+        val body = request.body.readUtf8()
+        assertTrue(body.contains("\"name\":\"Mercury\""))
+        assertTrue(body.contains("\"organization\":\"BPI\""))
+        assertEquals(99, created.id)
+        assertEquals("Mercury", created.name)
+    }
+
+    @Test
+    fun `associatePrizeToMusician hace POST a la ruta musicians y manda la fecha`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(ASSOCIATION_RESPONSE_JSON))
+
+        api.associatePrizeToMusician(7, 22, PerformerPrizeBody(premiationDate = "2024-05-01"))
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/prizes/7/musicians/22", request.path)
+        assertTrue(request.body.readUtf8().contains("\"premiationDate\":\"2024-05-01\""))
+    }
+
+    @Test
+    fun `associatePrizeToBand hace POST a la ruta bands`() = runTest {
+        server.enqueue(MockResponse().setResponseCode(200).setBody(ASSOCIATION_RESPONSE_JSON))
+
+        api.associatePrizeToBand(7, 33, PerformerPrizeBody(premiationDate = "1999-12-31"))
+
+        val request = server.takeRequest()
+        assertEquals("POST", request.method)
+        assertEquals("/prizes/7/bands/33", request.path)
+    }
+
     private companion object {
         const val SAMPLE_ALBUMS_JSON = """
         [
@@ -109,6 +174,21 @@ class VinilosApiContractTest {
             "tracks": []
           }
         ]
+        """
+
+        const val SAMPLE_PRIZES_JSON = """
+        [
+          { "id": 1, "name": "Grammy", "description": "Music award", "organization": "NARAS" },
+          { "id": 2, "name": "Latin Grammy", "description": "Latin music award", "organization": "LARAS" }
+        ]
+        """
+
+        const val CREATED_PRIZE_JSON = """
+        { "id": 99, "name": "Mercury", "description": "UK", "organization": "BPI" }
+        """
+
+        const val ASSOCIATION_RESPONSE_JSON = """
+        { "id": 5, "premiationDate": "2024-05-01" }
         """
     }
 }

--- a/app/src/test/java/com/uniandes/vinilos/repository/PrizeRepositoryTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/repository/PrizeRepositoryTest.kt
@@ -1,0 +1,128 @@
+package com.uniandes.vinilos.repository
+
+import com.uniandes.vinilos.database.dao.PrizeDao
+import com.uniandes.vinilos.database.entities.PrizeEntity
+import com.uniandes.vinilos.model.PerformerPrize
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.network.PerformerPrizeBody
+import com.uniandes.vinilos.network.PrizeCreateBody
+import com.uniandes.vinilos.network.VinilosApi
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class PrizeRepositoryTest {
+
+    private lateinit var dao: PrizeDao
+    private lateinit var api: VinilosApi
+    private lateinit var repository: PrizeRepository
+
+    private val cachedEntities = listOf(
+        PrizeEntity(1, "Grammy", "Music recognition", "NARAS"),
+        PrizeEntity(2, "Latin Grammy", "Latin music recognition", "LARAS")
+    )
+
+    private val remotePrizes = listOf(
+        Prize(10, "Polar Music Prize", "International prize", "Royal Swedish Academy")
+    )
+
+    @Before
+    fun setup() {
+        dao = mockk(relaxed = true)
+        api = mockk(relaxed = true)
+        repository = PrizeRepository(dao, api)
+    }
+
+    @Test
+    fun `getPrizes returns cached data when dao is not empty`() = runTest {
+        coEvery { dao.getAll() } returns cachedEntities
+
+        val result = repository.getPrizes()
+
+        assertEquals(2, result.size)
+        assertEquals("Grammy", result[0].name)
+        coVerify(exactly = 0) { api.getPrizes() }
+    }
+
+    @Test
+    fun `getPrizes hits the api and caches when dao is empty`() = runTest {
+        coEvery { dao.getAll() } returns emptyList()
+        coEvery { api.getPrizes() } returns remotePrizes
+
+        val result = repository.getPrizes()
+
+        assertEquals(1, result.size)
+        assertEquals("Polar Music Prize", result[0].name)
+        coVerify(exactly = 1) { api.getPrizes() }
+        coVerify(exactly = 1) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `refreshPrizes deletes cache and refetches`() = runTest {
+        coEvery { api.getPrizes() } returns remotePrizes
+
+        repository.refreshPrizes()
+
+        coVerify(exactly = 1) { dao.deleteAll() }
+        coVerify(exactly = 1) { api.getPrizes() }
+        coVerify(exactly = 1) { dao.insertAll(any()) }
+    }
+
+    @Test
+    fun `createPrize posts to api and caches the created prize`() = runTest {
+        val created = Prize(50, "Mercury Prize", "UK prize", "BPI")
+        coEvery { api.createPrize(any()) } returns created
+
+        val result = repository.createPrize(
+            name = "Mercury Prize",
+            description = "UK prize",
+            organization = "BPI"
+        )
+
+        assertEquals(50, result.id)
+        coVerify(exactly = 1) {
+            api.createPrize(PrizeCreateBody("Mercury Prize", "UK prize", "BPI"))
+        }
+        coVerify(exactly = 1) { dao.insert(any()) }
+    }
+
+    @Test
+    fun `associatePrizeToPerformer routes musicians to the musicians endpoint`() = runTest {
+        val response = PerformerPrize(1, "2024-01-15")
+        coEvery { api.associatePrizeToMusician(any(), any(), any()) } returns response
+
+        repository.associatePrizeToPerformer(
+            prizeId = 5,
+            performerId = 99,
+            isMusician = true,
+            premiationDate = "2024-01-15"
+        )
+
+        coVerify(exactly = 1) {
+            api.associatePrizeToMusician(5, 99, PerformerPrizeBody("2024-01-15"))
+        }
+        coVerify(exactly = 0) { api.associatePrizeToBand(any(), any(), any()) }
+    }
+
+    @Test
+    fun `associatePrizeToPerformer routes bands to the bands endpoint`() = runTest {
+        val response = PerformerPrize(2, "1999-12-31")
+        coEvery { api.associatePrizeToBand(any(), any(), any()) } returns response
+
+        repository.associatePrizeToPerformer(
+            prizeId = 7,
+            performerId = 42,
+            isMusician = false,
+            premiationDate = "1999-12-31"
+        )
+
+        coVerify(exactly = 1) {
+            api.associatePrizeToBand(7, 42, PerformerPrizeBody("1999-12-31"))
+        }
+        coVerify(exactly = 0) { api.associatePrizeToMusician(any(), any(), any()) }
+    }
+}

--- a/app/src/test/java/com/uniandes/vinilos/ui/prizes/PrizeViewModelTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/prizes/PrizeViewModelTest.kt
@@ -1,0 +1,226 @@
+package com.uniandes.vinilos.ui.prizes
+
+import com.uniandes.vinilos.model.PerformerPrize
+import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.repository.PrizeRepository
+import com.uniandes.vinilos.testing.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.ResponseBody.Companion.toResponseBody
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import retrofit2.HttpException
+import retrofit2.Response
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class PrizeViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val samplePrizes = listOf(
+        Prize(1, "Grammy", "Music award", "NARAS"),
+        Prize(2, "Latin Grammy", "Latin music award", "LARAS")
+    )
+
+    @Test
+    fun `init carga la lista de premios`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } returns samplePrizes
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(2, vm.prizes.value.size)
+        assertFalse(vm.isLoading.value)
+        assertNull(vm.error.value)
+        coVerify(exactly = 1) { repo.getPrizes() }
+    }
+
+    @Test
+    fun `IOException expone mensaje sin conexion`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } throws IOException("offline")
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(
+            "Sin conexión. Revisa tu red e inténtalo de nuevo.",
+            vm.error.value
+        )
+    }
+
+    @Test
+    fun `HttpException expone el codigo del servidor`() = runTest {
+        val httpError = HttpException(
+            Response.error<Any>(500, "".toResponseBody("application/json".toMediaTypeOrNull()))
+        )
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } throws httpError
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        assertEquals(
+            "El servidor respondió con un error (500).",
+            vm.error.value
+        )
+    }
+
+    @Test
+    fun `submitAssociation con fecha vacia produce error sin llamar al repo`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } returns samplePrizes
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        vm.submitAssociation(
+            performerId = 1,
+            isMusician = true,
+            premiationDate = "",
+            selectedPrizeId = 1,
+            newPrizeName = null,
+            newPrizeDescription = null,
+            newPrizeOrganization = null
+        )
+        advanceUntilIdle()
+
+        assertEquals("La fecha de premiación es obligatoria.", vm.error.value)
+        coVerify(exactly = 0) { repo.associatePrizeToPerformer(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `submitAssociation sin seleccion ni nuevo premio produce error`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } returns samplePrizes
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        vm.submitAssociation(
+            performerId = 1,
+            isMusician = true,
+            premiationDate = "2024-01-01",
+            selectedPrizeId = null,
+            newPrizeName = "",
+            newPrizeDescription = "",
+            newPrizeOrganization = ""
+        )
+        advanceUntilIdle()
+
+        assertNotNull(vm.error.value)
+        coVerify(exactly = 0) { repo.associatePrizeToPerformer(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `submitAssociation con premio existente asocia y expone success`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } returns samplePrizes
+        coEvery {
+            repo.associatePrizeToPerformer(prizeId = 1, performerId = 99, isMusician = true, premiationDate = "2024-05-01")
+        } returns PerformerPrize(id = 7, premiationDate = "2024-05-01")
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        vm.submitAssociation(
+            performerId = 99,
+            isMusician = true,
+            premiationDate = "2024-05-01",
+            selectedPrizeId = 1,
+            newPrizeName = null,
+            newPrizeDescription = null,
+            newPrizeOrganization = null
+        )
+        advanceUntilIdle()
+
+        assertNotNull(vm.associationSuccess.value)
+        assertEquals(7, vm.associationSuccess.value!!.id)
+        coVerify(exactly = 0) { repo.createPrize(any(), any(), any()) }
+    }
+
+    @Test
+    fun `submitAssociation crea un premio nuevo antes de asociar`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        val createdPrize = Prize(99, "Mercury Prize", "UK", "BPI")
+        coEvery { repo.getPrizes() } returns samplePrizes
+        coEvery { repo.createPrize("Mercury Prize", "UK album of the year", "BPI") } returns createdPrize
+        coEvery {
+            repo.associatePrizeToPerformer(
+                prizeId = 99,
+                performerId = 5,
+                isMusician = false,
+                premiationDate = "2024-09-10"
+            )
+        } returns PerformerPrize(id = 42, premiationDate = "2024-09-10")
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        vm.submitAssociation(
+            performerId = 5,
+            isMusician = false,
+            premiationDate = "2024-09-10",
+            selectedPrizeId = null,
+            newPrizeName = "Mercury Prize",
+            newPrizeDescription = "UK album of the year",
+            newPrizeOrganization = "BPI"
+        )
+        advanceUntilIdle()
+
+        // El premio nuevo aparece en la lista visible para que la UI no parpadee
+        assertEquals(3, vm.prizes.value.size)
+        assertEquals(99, vm.prizes.value.last().id)
+        assertNotNull(vm.associationSuccess.value)
+        coVerify(exactly = 1) { repo.createPrize("Mercury Prize", "UK album of the year", "BPI") }
+        coVerify(exactly = 1) {
+            repo.associatePrizeToPerformer(99, 5, false, "2024-09-10")
+        }
+    }
+
+    @Test
+    fun `consumeAssociationSuccess limpia el flow de success`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } returns samplePrizes
+        coEvery {
+            repo.associatePrizeToPerformer(any(), any(), any(), any())
+        } returns PerformerPrize(id = 1, premiationDate = "2024-01-01")
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+
+        vm.submitAssociation(
+            performerId = 1, isMusician = true, premiationDate = "2024-01-01",
+            selectedPrizeId = 1, newPrizeName = null,
+            newPrizeDescription = null, newPrizeOrganization = null
+        )
+        advanceUntilIdle()
+        assertNotNull(vm.associationSuccess.value)
+
+        vm.consumeAssociationSuccess()
+        assertNull(vm.associationSuccess.value)
+    }
+
+    @Test
+    fun `clearError limpia el mensaje de error`() = runTest {
+        val repo = mockk<PrizeRepository>(relaxed = true)
+        coEvery { repo.getPrizes() } throws IOException("offline")
+
+        val vm = PrizeViewModel(repo)
+        advanceUntilIdle()
+        assertNotNull(vm.error.value)
+
+        vm.clearError()
+        assertNull(vm.error.value)
+    }
+}

--- a/kraken/features/prize_associate.feature
+++ b/kraken/features/prize_associate.feature
@@ -1,0 +1,58 @@
+Feature: Asociar premios a artistas (HU13)
+
+  @user1 @mobile
+  Scenario: Como visitante NO veo la opción de asociar premios en el detalle del artista
+    Given I wait
+    Then I select role if needed
+    Then I tap on element with accessibility id "nav_artistas"
+    Then I wait
+    Then I wait
+    Then I wait
+    Then I tap on element with text containing "Rubén Blades Bellido de Luna"
+    Then I wait
+    Then I wait
+    Then I scroll up
+    Then I scroll up
+    Then I don't see the text "Asociar premio"
+    Then I tap on element with accessibility id "Volver"
+    Then I wait
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait
+
+  @user2 @mobile
+  Scenario: Como coleccionista veo la opción de asociar premios y puedo abrir el formulario
+    Given I wait
+    Then I select role if needed
+    Then I tap on element with accessibility id "nav_artistas"
+    Then I wait
+    Then I wait
+    Then I wait
+    Then I tap on element with text containing "Rubén Blades Bellido de Luna"
+    Then I wait
+    Then I wait
+    Then I tap on element with accessibility id "Abrir menú"
+    Then I wait
+    Then I tap on element with text containing "Hacerse coleccionista"
+    Then I wait
+    Then I wait
+    Then I scroll up
+    Then I scroll up
+    Then I see the text "LOS GALARDONES"
+    Then I tap on element with text containing "Asociar premio"
+    Then I wait
+    Then I wait
+    Then I see the text "Para Rubén"
+    Then I see the text "PASO 1"
+    Then I see the text "PASO 2"
+    Then I tap on element with text containing "Crear un nuevo premio"
+    Then I wait
+    Then I see the text "Nombre del premio"
+    Then I see the text "Organización"
+    Then I tap on element with accessibility id "Volver"
+    Then I wait
+    Then I tap on element with accessibility id "Abrir menú"
+    Then I wait
+    Then I tap on element with text containing "Salir del modo coleccionista"
+    Then I wait
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait


### PR DESCRIPTION
## Resumen
- Nuevo flujo para que el coleccionista cree premios y los asocie a un artista (musician o band) desde el detalle del artista.
- Capa completa siguiendo los patrones existentes: modelo `Prize`/`PerformerPrize`, entidad Room + DAO + mapper + migración 3→4, endpoints `GET/POST /prizes` y `POST /prizes/{id}/musicians|bands/{id}` en `VinilosApi`, `PrizeRepository` cache-first, `PrizeViewModel` con flows granulares y factory pattern.
- Pantalla `PrizeAssociateScreen` (formulario en dos pasos: elegir premio existente o crear uno nuevo + fecha de premiación) y sección "GALARDONES" en el detalle del artista visible **solo para `UserRole.COLLECTOR`**.

## Test plan
- [x] `./gradlew testDebugUnitTest` verde — `PrizeRepositoryTest` (6), `PrizeViewModelTest` (9), `VinilosApiContractTest` +5 casos para los endpoints de premios.
- [x] `./gradlew assembleDebugAndroidTest` compila — `PrizeAssociateScreenInstrumentedTest` (6) + 3 nuevos casos en `ArtistDetailScreenInstrumentedTest` para el gating por rol.
- [x] Kraken `prize_associate.feature` (2 escenarios: visitante no ve CTA, coleccionista llega al formulario) — requiere device/emulador.
- [x] Smoke manual: visitante no ve CTA; coleccionista crea premio nuevo + lo asocia con fecha; back regresa al detalle del artista.