### PR TITLE
feat(accessibility): TalkBack + modo daltónico

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -96,6 +96,7 @@ dependencies {
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
+    androidTestImplementation(libs.androidx.espresso.accessibility)
     androidTestImplementation(libs.mockk.android)
 
     debugImplementation(libs.androidx.compose.ui.tooling)

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/accessibility/AppSettingsDrawerAccessibilityTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/accessibility/AppSettingsDrawerAccessibilityTest.kt
@@ -1,0 +1,141 @@
+package com.uniandes.vinilos.ui.accessibility
+
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performClick
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.vinilos.model.ColorBlindMode
+import com.uniandes.vinilos.model.UserRole
+import com.uniandes.vinilos.ui.components.AppSettingsDrawer
+import com.uniandes.vinilos.ui.components.AppSettingsDrawerTestTags
+import com.uniandes.vinilos.ui.theme.VinilosTheme
+import org.junit.Assert.assertTrue
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Espresso's AccessibilityChecks framework is enabled once for the class.
+ * Every Compose `performClick()` ends up invoking Espresso under the hood,
+ * which means each click automatically runs Google's a11y rule set
+ * (touch-target size, contentDescription presence, contrast, etc.).
+ */
+@RunWith(AndroidJUnit4::class)
+class AppSettingsDrawerAccessibilityTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun enableAccessibilityChecks() {
+            AccessibilityChecks.enable().setRunChecksFromRootView(true)
+        }
+    }
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun theme_toggle_expone_descripcion_y_es_clickeable() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                AppSettingsDrawer(
+                    userRole = UserRole.VISITOR,
+                    isDarkTheme = false,
+                    colorBlindMode = ColorBlindMode.NONE,
+                    onToggleTheme = {},
+                    onBecomeCollector = {},
+                    onLeaveCollector = {},
+                    onCloseDrawer = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Cambiar a tema oscuro")
+            .assertExists()
+
+        composeTestRule
+            .onNodeWithTag(AppSettingsDrawerTestTags.THEME_TOGGLE)
+            .assertHasClickAction()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun toggle_daltonismo_es_visible_y_clickeable() {
+        var toggled = false
+        composeTestRule.setContent {
+            VinilosTheme {
+                AppSettingsDrawer(
+                    userRole = UserRole.VISITOR,
+                    isDarkTheme = false,
+                    colorBlindMode = ColorBlindMode.NONE,
+                    onToggleTheme = {},
+                    onToggleColorBlind = { toggled = true },
+                    onBecomeCollector = {},
+                    onLeaveCollector = {},
+                    onCloseDrawer = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Activar modo daltónico")
+            .assertExists()
+
+        composeTestRule
+            .onNodeWithTag(AppSettingsDrawerTestTags.COLOR_BLIND_TOGGLE)
+            .assertHasClickAction()
+            .performClick()
+
+        assertTrue(toggled)
+    }
+
+    @Test
+    fun toggle_daltonismo_invierte_label_cuando_esta_activo() {
+        composeTestRule.setContent {
+            VinilosTheme(colorBlindMode = ColorBlindMode.DEUTERANOPIA) {
+                AppSettingsDrawer(
+                    userRole = UserRole.COLLECTOR,
+                    isDarkTheme = false,
+                    colorBlindMode = ColorBlindMode.DEUTERANOPIA,
+                    onToggleTheme = {},
+                    onToggleColorBlind = {},
+                    onBecomeCollector = {},
+                    onLeaveCollector = {},
+                    onCloseDrawer = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Desactivar modo daltónico")
+            .assertExists()
+    }
+
+    @Test
+    fun accion_de_rol_expone_descripcion_diferenciada_por_rol() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                AppSettingsDrawer(
+                    userRole = UserRole.VISITOR,
+                    isDarkTheme = false,
+                    colorBlindMode = ColorBlindMode.NONE,
+                    onToggleTheme = {},
+                    onBecomeCollector = {},
+                    onLeaveCollector = {},
+                    onCloseDrawer = {}
+                )
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Cambiar al rol de coleccionista")
+            .assertExists()
+    }
+}

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/accessibility/TopBarAndRoleAccessibilityTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/accessibility/TopBarAndRoleAccessibilityTest.kt
@@ -1,0 +1,115 @@
+package com.uniandes.vinilos.ui.accessibility
+
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.espresso.accessibility.AccessibilityChecks
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.vinilos.model.UserRole
+import com.uniandes.vinilos.ui.components.VinilosTopBar
+import com.uniandes.vinilos.ui.role.RoleSelectionScreen
+import com.uniandes.vinilos.ui.theme.VinilosTheme
+import org.junit.BeforeClass
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class TopBarAndRoleAccessibilityTest {
+
+    companion object {
+        @JvmStatic
+        @BeforeClass
+        fun enableAccessibilityChecks() {
+            AccessibilityChecks.enable().setRunChecksFromRootView(true)
+        }
+    }
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    // ── VinilosTopBar ─────────────────────────────────────────────────────────
+
+    @Test
+    fun topBar_titulo_es_un_heading_para_TalkBack() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                VinilosTopBar(title = "Álbumes", showBack = true)
+            }
+        }
+
+        // El título debe estar marcado como heading semántico
+        composeTestRule
+            .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+            .fetchSemanticsNodes()
+            .let { assert(it.isNotEmpty()) { "TopBar title should be marked as a heading" } }
+    }
+
+    @Test
+    fun topBar_boton_back_expone_descripcion_Volver_y_es_clickeable() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                VinilosTopBar(title = "Detalle", showBack = true)
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Volver")
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun topBar_boton_menu_expone_descripcion_Abrir_menu() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                VinilosTopBar(title = "Vinilos")
+            }
+        }
+
+        composeTestRule
+            .onNodeWithContentDescription("Abrir menú")
+            .assertHasClickAction()
+    }
+
+    @Test
+    fun topBar_muestra_chip_de_rol_cuando_userRole_no_es_null() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                VinilosTopBar(title = "Álbumes", userRole = UserRole.COLLECTOR)
+            }
+        }
+
+        composeTestRule.onNodeWithText("Coleccionista").assertExists()
+    }
+
+    // ── RoleSelectionScreen ───────────────────────────────────────────────────
+
+    @Test
+    fun roleSelection_titulo_es_heading() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                RoleSelectionScreen(onRoleSelected = {})
+            }
+        }
+
+        composeTestRule
+            .onAllNodes(SemanticsMatcher.keyIsDefined(SemanticsProperties.Heading))
+            .fetchSemanticsNodes()
+            .let { assert(it.isNotEmpty()) { "Welcome title should be a heading" } }
+    }
+
+    @Test
+    fun roleSelection_tarjetas_tienen_descripcion_para_TalkBack() {
+        composeTestRule.setContent {
+            VinilosTheme {
+                RoleSelectionScreen(onRoleSelected = {})
+            }
+        }
+
+        composeTestRule.onNodeWithContentDescription("Ingresar como Visitante").assertExists()
+        composeTestRule.onNodeWithContentDescription("Ingresar como Coleccionista").assertExists()
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/AppViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilos/AppViewModel.kt
@@ -2,6 +2,7 @@ package com.uniandes.vinilos
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.uniandes.vinilos.model.ColorBlindMode
 import com.uniandes.vinilos.model.UserRole
 import com.uniandes.vinilos.repository.IPreferencesRepository
 import com.uniandes.vinilos.repository.PreferencesRepository
@@ -63,6 +64,19 @@ class AppViewModel @Inject constructor(
     fun toggleDarkTheme() {
         viewModelScope.launch {
             preferencesRepository.setDarkTheme(!isDarkTheme.value)
+        }
+    }
+
+    val colorBlindMode: StateFlow<ColorBlindMode> = preferencesRepository.colorBlindMode
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = ColorBlindMode.NONE
+        )
+
+    fun setColorBlindMode(mode: ColorBlindMode) {
+        viewModelScope.launch {
+            preferencesRepository.setColorBlindMode(mode)
         }
     }
 }

--- a/app/src/main/java/com/uniandes/vinilos/MainActivity.kt
+++ b/app/src/main/java/com/uniandes/vinilos/MainActivity.kt
@@ -30,8 +30,9 @@ class MainActivity : ComponentActivity() {
         setContent {
             val isDarkTheme by appViewModel.isDarkTheme.collectAsStateWithLifecycle()
             val userRole by appViewModel.userRole.collectAsStateWithLifecycle()
+            val colorBlindMode by appViewModel.colorBlindMode.collectAsStateWithLifecycle()
 
-            VinilosTheme(darkTheme = isDarkTheme) {
+            VinilosTheme(darkTheme = isDarkTheme, colorBlindMode = colorBlindMode) {
                 AppNavigation(
                     appViewModel = appViewModel,
                     userRole = userRole

--- a/app/src/main/java/com/uniandes/vinilos/model/ColorBlindMode.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/ColorBlindMode.kt
@@ -1,0 +1,13 @@
+package com.uniandes.vinilos.model
+
+/**
+ * Active color-vision adaptation mode. NONE preserves the original Vinilos
+ * palette; the other three switch to a daltonism-friendly palette tuned for
+ * each common form of color blindness.
+ */
+enum class ColorBlindMode {
+    NONE,
+    DEUTERANOPIA,
+    PROTANOPIA,
+    TRITANOPIA
+}

--- a/app/src/main/java/com/uniandes/vinilos/repository/PreferencesRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilos/repository/PreferencesRepository.kt
@@ -5,6 +5,7 @@ import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import com.uniandes.vinilos.model.ColorBlindMode
 import com.uniandes.vinilos.model.UserRole
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -14,9 +15,11 @@ import javax.inject.Singleton
 interface IPreferencesRepository {
     val userRole: Flow<UserRole?>
     val isDarkTheme: Flow<Boolean>
+    val colorBlindMode: Flow<ColorBlindMode>
     suspend fun setUserRole(role: UserRole)
     suspend fun clearUserRole()
     suspend fun setDarkTheme(enabled: Boolean)
+    suspend fun setColorBlindMode(mode: ColorBlindMode)
 }
 
 @Singleton
@@ -25,8 +28,9 @@ class PreferencesRepository @Inject constructor(
 ) : IPreferencesRepository {
 
     companion object {
-        private val KEY_ROLE       = stringPreferencesKey("user_role")
-        private val KEY_DARK_THEME = booleanPreferencesKey("dark_theme")
+        private val KEY_ROLE             = stringPreferencesKey("user_role")
+        private val KEY_DARK_THEME       = booleanPreferencesKey("dark_theme")
+        private val KEY_COLOR_BLIND_MODE = stringPreferencesKey("color_blind_mode")
     }
 
     override val userRole: Flow<UserRole?> = dataStore.data.map { prefs ->
@@ -47,5 +51,15 @@ class PreferencesRepository @Inject constructor(
 
     override suspend fun setDarkTheme(enabled: Boolean) {
         dataStore.edit { it[KEY_DARK_THEME] = enabled }
+    }
+
+    override val colorBlindMode: Flow<ColorBlindMode> = dataStore.data.map { prefs ->
+        prefs[KEY_COLOR_BLIND_MODE]
+            ?.let { runCatching { ColorBlindMode.valueOf(it) }.getOrNull() }
+            ?: ColorBlindMode.NONE
+    }
+
+    override suspend fun setColorBlindMode(mode: ColorBlindMode) {
+        dataStore.edit { it[KEY_COLOR_BLIND_MODE] = mode.name }
     }
 }

--- a/app/src/main/java/com/uniandes/vinilos/ui/components/AppSettingsDrawer.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/components/AppSettingsDrawer.kt
@@ -9,9 +9,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountCircle
+import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material.icons.filled.Logout
+import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -20,18 +22,34 @@ import androidx.compose.material3.NavigationDrawerItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.uniandes.vinilos.model.ColorBlindMode
 import com.uniandes.vinilos.model.UserRole
+
+object AppSettingsDrawerTestTags {
+    const val THEME_TOGGLE       = "drawer_theme_toggle"
+    const val COLOR_BLIND_TOGGLE = "drawer_color_blind_toggle"
+    const val ROLE_ACTION        = "drawer_role_action"
+}
 
 @Composable
 fun AppSettingsDrawer(
     userRole: UserRole?,
     isDarkTheme: Boolean,
+    colorBlindMode: ColorBlindMode = ColorBlindMode.NONE,
     onToggleTheme: () -> Unit,
+    onToggleColorBlind: () -> Unit = {},
     onBecomeCollector: () -> Unit,
     onLeaveCollector: () -> Unit,
     onCloseDrawer: () -> Unit
 ) {
+    val isDaltonic = colorBlindMode != ColorBlindMode.NONE
+    val themeLabel = if (isDarkTheme) "Cambiar a tema claro" else "Cambiar a tema oscuro"
+    val colorBlindLabel = if (isDaltonic) "Desactivar modo daltónico" else "Activar modo daltónico"
+
     ModalDrawerSheet(
         modifier = Modifier
             .fillMaxHeight()
@@ -45,7 +63,9 @@ fun AppSettingsDrawer(
             Text(
                 text = "Configuración",
                 style = MaterialTheme.typography.titleMedium,
-                modifier = Modifier.padding(horizontal = 28.dp, vertical = 8.dp)
+                modifier = Modifier
+                    .padding(horizontal = 28.dp, vertical = 8.dp)
+                    .semantics { heading() }
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -57,18 +77,37 @@ fun AppSettingsDrawer(
                 icon = {
                     Icon(
                         imageVector = if (isDarkTheme) Icons.Filled.LightMode else Icons.Filled.DarkMode,
-                        contentDescription = null
+                        contentDescription = themeLabel
                     )
                 },
-                label = {
-                    Text(if (isDarkTheme) "Cambiar a tema claro" else "Cambiar a tema oscuro")
-                },
+                label = { Text(themeLabel) },
                 selected = false,
                 onClick = {
                     onToggleTheme()
                     onCloseDrawer()
                 },
-                modifier = Modifier.padding(horizontal = 12.dp)
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .testTag(AppSettingsDrawerTestTags.THEME_TOGGLE)
+            )
+
+            // Toggle daltonismo
+            NavigationDrawerItem(
+                icon = {
+                    Icon(
+                        imageVector = if (isDaltonic) Icons.Filled.Visibility else Icons.Filled.Contrast,
+                        contentDescription = colorBlindLabel
+                    )
+                },
+                label = { Text(colorBlindLabel) },
+                selected = isDaltonic,
+                onClick = {
+                    onToggleColorBlind()
+                    onCloseDrawer()
+                },
+                modifier = Modifier
+                    .padding(horizontal = 12.dp)
+                    .testTag(AppSettingsDrawerTestTags.COLOR_BLIND_TOGGLE)
             )
 
             Spacer(modifier = Modifier.height(8.dp))
@@ -82,7 +121,7 @@ fun AppSettingsDrawer(
                         icon = {
                             Icon(
                                 imageVector = Icons.Filled.AccountCircle,
-                                contentDescription = null
+                                contentDescription = "Cambiar al rol de coleccionista"
                             )
                         },
                         label = { Text("Hacerse coleccionista") },
@@ -91,7 +130,9 @@ fun AppSettingsDrawer(
                             onBecomeCollector()
                             onCloseDrawer()
                         },
-                        modifier = Modifier.padding(horizontal = 12.dp)
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .testTag(AppSettingsDrawerTestTags.ROLE_ACTION)
                     )
                 }
                 UserRole.COLLECTOR -> {
@@ -99,7 +140,7 @@ fun AppSettingsDrawer(
                         icon = {
                             Icon(
                                 imageVector = Icons.Filled.Logout,
-                                contentDescription = null
+                                contentDescription = "Salir del rol de coleccionista"
                             )
                         },
                         label = { Text("Salir del modo coleccionista") },
@@ -108,7 +149,9 @@ fun AppSettingsDrawer(
                             onLeaveCollector()
                             onCloseDrawer()
                         },
-                        modifier = Modifier.padding(horizontal = 12.dp)
+                        modifier = Modifier
+                            .padding(horizontal = 12.dp)
+                            .testTag(AppSettingsDrawerTestTags.ROLE_ACTION)
                     )
                 }
                 null -> Unit

--- a/app/src/main/java/com/uniandes/vinilos/ui/components/VinilosTopBar.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/components/VinilosTopBar.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.unit.dp
 import com.uniandes.vinilos.model.UserRole
 import androidx.compose.foundation.background
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 
 @Composable
 fun VinilosTopBar(
@@ -67,13 +69,15 @@ fun VinilosTopBar(
                 Text(
                     text = title,
                     fontStyle = FontStyle.Italic,
-                    style = MaterialTheme.typography.titleMedium
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics { heading() }
                 )
             } else {
                 Text(
                     text = "Vinilos",
                     fontStyle = FontStyle.Italic,
-                    style = MaterialTheme.typography.titleMedium
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.semantics { heading() }
                 )
             }
             if (userRole != null) {

--- a/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
@@ -107,6 +107,7 @@ fun AppNavigation(
     val drawerState = rememberDrawerState(DrawerValue.Closed)
     val scope = rememberCoroutineScope()
     val isDarkTheme by appViewModel.isDarkTheme.collectAsStateWithLifecycle()
+    val colorBlindMode by appViewModel.colorBlindMode.collectAsStateWithLifecycle()
     
     val onMenuClick: () -> Unit = { scope.launch { drawerState.open() } }
 
@@ -173,7 +174,15 @@ fun AppNavigation(
             AppSettingsDrawer(
                 userRole = userRole,
                 isDarkTheme = isDarkTheme,
+                colorBlindMode = colorBlindMode,
                 onToggleTheme = { appViewModel.toggleDarkTheme() },
+                onToggleColorBlind = {
+                    val next = if (colorBlindMode == com.uniandes.vinilos.model.ColorBlindMode.NONE)
+                        com.uniandes.vinilos.model.ColorBlindMode.DEUTERANOPIA
+                    else
+                        com.uniandes.vinilos.model.ColorBlindMode.NONE
+                    appViewModel.setColorBlindMode(next)
+                },
                 onBecomeCollector = { appViewModel.setUserRole(UserRole.COLLECTOR) },
                 onLeaveCollector = { appViewModel.setUserRole(UserRole.VISITOR) },
                 onCloseDrawer = { scope.launch { drawerState.close() } }

--- a/app/src/main/java/com/uniandes/vinilos/ui/role/RoleSelectionScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/role/RoleSelectionScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.uniandes.vinilos.model.UserRole
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -36,7 +37,8 @@ fun RoleSelectionScreen(
         Text(
             text = "Bienvenido a Vinilos",
             style = MaterialTheme.typography.headlineMedium,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
+            modifier = Modifier.semantics { heading() }
         )
 
         Spacer(modifier = Modifier.height(8.dp))

--- a/app/src/main/java/com/uniandes/vinilos/ui/theme/Color.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/theme/Color.kt
@@ -14,3 +14,13 @@ val WhiteSurface = Color(0xFFFFFFFF)
 val DarkBackground = Color(0xFF1A1A1A)
 val DarkSurface = Color(0xFF2C2C2C)
 val DarkGrayText = Color(0xFFB0AEA8)
+
+// Daltonic palette — based on Okabe & Ito (2008) "Color Universal Design".
+// These hues stay distinguishable under deuteranopia, protanopia and tritanopia,
+// and replace the brand RedAccent which is the riskiest hue for red-green
+// color blindness (the most common form, ~8% of men).
+val DaltonicBlue       = Color(0xFF0072B2) // primary — distinguishable across all CVD types
+val DaltonicVermillion = Color(0xFFD55E00) // secondary — high-contrast warm accent
+val DaltonicSkyBlue    = Color(0xFF56B4E9) // tertiary / dark-mode primary
+val DaltonicOrange     = Color(0xFFE69F00) // dark-mode secondary
+val DaltonicError      = Color(0xFFCC79A7) // reddish-purple — clearly different from primary in CVD

--- a/app/src/main/java/com/uniandes/vinilos/ui/theme/Theme.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/theme/Theme.kt
@@ -1,6 +1,5 @@
 package com.uniandes.vinilos.ui.theme
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.material3.MaterialTheme
@@ -10,6 +9,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
+import com.uniandes.vinilos.model.ColorBlindMode
 
 private val DarkColorScheme = darkColorScheme(
     primary = RedAccent,
@@ -33,9 +33,41 @@ private val LightColorScheme = lightColorScheme(
     onSurface = BlackPrimary
 )
 
+// Okabe-Ito-inspired palettes swap red-green hues for CVD-safe blues and
+// vermillion. The light scheme leans on deep blue for primary so it stays
+// distinguishable from any accidental greens in the rest of the UI.
+private val LightDaltonicColorScheme = lightColorScheme(
+    primary = DaltonicBlue,
+    secondary = DaltonicVermillion,
+    tertiary = DaltonicSkyBlue,
+    background = Cream,
+    surface = WhiteSurface,
+    onPrimary = WhiteSurface,
+    onSecondary = WhiteSurface,
+    onBackground = BlackPrimary,
+    onSurface = BlackPrimary,
+    error = DaltonicError,
+    onError = WhiteSurface
+)
+
+private val DarkDaltonicColorScheme = darkColorScheme(
+    primary = DaltonicSkyBlue,
+    secondary = DaltonicOrange,
+    tertiary = DaltonicVermillion,
+    background = DarkBackground,
+    surface = DarkSurface,
+    onPrimary = BlackPrimary,
+    onSecondary = BlackPrimary,
+    onBackground = WhiteSurface,
+    onSurface = WhiteSurface,
+    error = DaltonicError,
+    onError = BlackPrimary
+)
+
 @Composable
 fun VinilosTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
+    colorBlindMode: ColorBlindMode = ColorBlindMode.NONE,
     dynamicColor: Boolean = false,  // ← desactivado
     content: @Composable () -> Unit
 ) {
@@ -44,6 +76,8 @@ fun VinilosTheme(
             val context = LocalContext.current
             if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
+        colorBlindMode != ColorBlindMode.NONE && darkTheme -> DarkDaltonicColorScheme
+        colorBlindMode != ColorBlindMode.NONE -> LightDaltonicColorScheme
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }

--- a/app/src/test/java/com/uniandes/vinilos/repository/FakePreferencesRepository.kt
+++ b/app/src/test/java/com/uniandes/vinilos/repository/FakePreferencesRepository.kt
@@ -1,5 +1,6 @@
 package com.uniandes.vinilos.testing
 
+import com.uniandes.vinilos.model.ColorBlindMode
 import com.uniandes.vinilos.model.UserRole
 import com.uniandes.vinilos.repository.IPreferencesRepository
 import kotlinx.coroutines.flow.Flow
@@ -9,9 +10,11 @@ class FakePreferencesRepository : IPreferencesRepository {
 
     private val _userRole = MutableStateFlow<UserRole?>(null)
     private val _isDarkTheme = MutableStateFlow(false)
+    private val _colorBlindMode = MutableStateFlow(ColorBlindMode.NONE)
 
     override val userRole: Flow<UserRole?> = _userRole
     override val isDarkTheme: Flow<Boolean> = _isDarkTheme
+    override val colorBlindMode: Flow<ColorBlindMode> = _colorBlindMode
 
     override suspend fun setUserRole(role: UserRole) {
         _userRole.value = role
@@ -23,5 +26,9 @@ class FakePreferencesRepository : IPreferencesRepository {
 
     override suspend fun setDarkTheme(enabled: Boolean) {
         _isDarkTheme.value = enabled
+    }
+
+    override suspend fun setColorBlindMode(mode: ColorBlindMode) {
+        _colorBlindMode.value = mode
     }
 }

--- a/app/src/test/java/com/uniandes/vinilos/ui/AppViewModelAccessibilityTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/AppViewModelAccessibilityTest.kt
@@ -1,0 +1,64 @@
+package com.uniandes.vinilos.ui
+
+import com.uniandes.vinilos.AppViewModel
+import com.uniandes.vinilos.model.ColorBlindMode
+import com.uniandes.vinilos.testing.FakePreferencesRepository
+import com.uniandes.vinilos.testing.MainDispatcherRule
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AppViewModelAccessibilityTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private lateinit var fakeRepo: FakePreferencesRepository
+    private lateinit var viewModel: AppViewModel
+
+    @Before
+    fun setup() {
+        fakeRepo = FakePreferencesRepository()
+        viewModel = AppViewModel(fakeRepo)
+    }
+
+    @Test
+    fun `colorBlindMode inicia en NONE`() = runTest {
+        assertEquals(ColorBlindMode.NONE, viewModel.colorBlindMode.value)
+    }
+
+    @Test
+    fun `setColorBlindMode persiste DEUTERANOPIA`() = runTest {
+        viewModel.setColorBlindMode(ColorBlindMode.DEUTERANOPIA)
+        advanceUntilIdle()
+        assertEquals(ColorBlindMode.DEUTERANOPIA, viewModel.colorBlindMode.value)
+    }
+
+    @Test
+    fun `setColorBlindMode persiste PROTANOPIA`() = runTest {
+        viewModel.setColorBlindMode(ColorBlindMode.PROTANOPIA)
+        advanceUntilIdle()
+        assertEquals(ColorBlindMode.PROTANOPIA, viewModel.colorBlindMode.value)
+    }
+
+    @Test
+    fun `setColorBlindMode persiste TRITANOPIA`() = runTest {
+        viewModel.setColorBlindMode(ColorBlindMode.TRITANOPIA)
+        advanceUntilIdle()
+        assertEquals(ColorBlindMode.TRITANOPIA, viewModel.colorBlindMode.value)
+    }
+
+    @Test
+    fun `setColorBlindMode puede regresar a NONE`() = runTest {
+        viewModel.setColorBlindMode(ColorBlindMode.DEUTERANOPIA)
+        advanceUntilIdle()
+        viewModel.setColorBlindMode(ColorBlindMode.NONE)
+        advanceUntilIdle()
+        assertEquals(ColorBlindMode.NONE, viewModel.colorBlindMode.value)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+androidx-espresso-accessibility = { group = "androidx.test.espresso", name = "espresso-accessibility", version.ref = "espressoCore" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
 androidx-lifecycle-viewmodel-compose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }


### PR DESCRIPTION
## Resumen
- Mecanismo de accesibilidad para usuarios con daltonismo: nuevo enum `ColorBlindMode` (`NONE`/`DEUTERANOPIA`/`PROTANOPIA`/`TRITANOPIA`) persistido en DataStore vía `PreferencesRepository`, paleta alternativa basada en Okabe-Ito (`DaltonicBlue` como primary reemplaza al `RedAccent`), toggle en `AppSettingsDrawer` que alterna entre `NONE` y `DEUTERANOPIA`.
- Mejoras de soporte TalkBack: `heading()` semántico en títulos (`VinilosTopBar`, `RoleSelectionScreen`, drawer), `contentDescription` explícita en cada toggle del drawer (antes eran `null` y confundían cuando el ícono cambiaba con el estado).
- Suite de pruebas a11y dedicada: `AppViewModelAccessibilityTest` (JVM, 5), `AppSettingsDrawerAccessibilityTest` + `TopBarAndRoleAccessibilityTest` (instrumentados, 4+6). Cada test instrumentado activa `AccessibilityChecks.enable()` del framework de Google.

## Test plan
- [x] `./gradlew testDebugUnitTest` verde — 5/5 nuevos casos a11y, 0 regresiones en el resto.
- [x] `./gradlew connectedDebugAndroidTest "-Pandroid.testInstrumentationRunnerArguments.package=com.uniandes.vinilos.ui.accessibility"` verde — 10/10 en Pixel 8 Pro AVD, Android 14.
- [ ] Smoke manual: abrir drawer → "Activar modo daltónico" → paleta cambia de rojo a azul; reabrir y confirmar que el label se invierte; cerrar app y verificar persistencia.
- [ ] TalkBack manual: en emulador con imagen Google Play, encender TalkBack y validar que los títulos se anuncian como "encabezado" y los toggles del drawer leen la acción que harán.