### PR TITLE
HU08 — Asociar tracks con un álbum

### DIFF
--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/albums/AddTrackScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/albums/AddTrackScreenInstrumentedTest.kt
@@ -1,0 +1,213 @@
+package com.uniandes.vinilos.ui.albums
+
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
+import androidx.compose.ui.test.performTextInput
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.uniandes.vinilos.model.Track
+import com.uniandes.vinilos.repository.AlbumRepository
+import com.uniandes.vinilos.ui.theme.VinilosTheme
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.delay
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class AddTrackScreenInstrumentedTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val albumId = 7
+    private val createdTrack = Track(id = 101, name = "So What", duration = "9:22")
+
+    private fun viewModelWith(
+        repoBlock: AlbumRepository.() -> Unit = {}
+    ): CreateTrackViewModel {
+        val repo = mockk<AlbumRepository>(relaxed = true).apply(repoBlock)
+        return CreateTrackViewModel(repo)
+    }
+
+    private fun setScreen(
+        viewModel: CreateTrackViewModel,
+        albumName: String = "Kind of Blue",
+        onSuccess: () -> Unit = {},
+        onDiscard: () -> Unit = {}
+    ) {
+        composeTestRule.setContent {
+            VinilosTheme {
+                AddTrackScreen(
+                    albumId = albumId,
+                    albumName = albumName,
+                    viewModel = viewModel,
+                    onSuccess = onSuccess,
+                    onDiscard = onDiscard
+                )
+            }
+        }
+    }
+
+    // ─── T1: La pantalla renderiza los elementos principales ─────────────────
+
+    @Test
+    fun addTrackScreen_muestraElementosPrincipales() {
+        setScreen(viewModelWith())
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.SCREEN).assertIsDisplayed()
+        composeTestRule.onNodeWithText("Asociar canción").assertIsDisplayed()
+        composeTestRule.onNodeWithText("TRACK ASSOCIATION").assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_NAME).assertExists()
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_DURATION).assertExists()
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).assertExists()
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_DISCARD).assertExists()
+    }
+
+    // ─── T2: La pantalla muestra el nombre del álbum recibido como contexto ──
+
+    @Test
+    fun addTrackScreen_muestraNombreDelAlbum() {
+        setScreen(viewModelWith(), albumName = "Abbey Road")
+
+        composeTestRule
+            .onNode(hasTestTag(AddTrackTestTags.SCREEN))
+            .assertExists()
+        composeTestRule.onNodeWithText(
+            "Agrega una canción al álbum \"Abbey Road\". Documenta el orden, la duración exacta y mantén el archivo curado.",
+            substring = false
+        ).assertExists()
+    }
+
+    // ─── T3: Submit vacío muestra errores de validación ──────────────────────
+
+    @Test
+    fun addTrackScreen_muestraErroresDeValidacion_conFormularioVacio() {
+        setScreen(viewModelWith())
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).performScrollTo().performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("${AddTrackTestTags.INPUT_NAME}_error"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText("El nombre de la canción es obligatorio").assertExists()
+        composeTestRule.onNodeWithText("La duración es obligatoria").assertExists()
+    }
+
+    // ─── T4: Formato de duración inválido muestra el error correspondiente ───
+
+    @Test
+    fun addTrackScreen_muestraErrorDeFormato_cuandoDuracionInvalida() {
+        setScreen(viewModelWith())
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_NAME)
+            .performScrollTo().performTextInput("So What")
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_DURATION)
+            .performScrollTo().performTextInput("nueve minutos")
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).performScrollTo().performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 3_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag("${AddTrackTestTags.INPUT_DURATION}_error"))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithText("Formato esperado mm:ss (ej. 3:45)").assertExists()
+    }
+
+    // ─── T5: Flujo exitoso invoca el callback onSuccess ──────────────────────
+
+    @Test
+    fun addTrackScreen_submitExitoso_invocaOnSuccess() {
+        var successInvoked = false
+        val vm = viewModelWith {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.success(createdTrack)
+        }
+        setScreen(vm, onSuccess = { successInvoked = true })
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_NAME)
+            .performScrollTo().performTextInput("So What")
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_DURATION)
+            .performScrollTo().performTextInput("9:22")
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).performScrollTo().performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) { successInvoked }
+
+        assertTrue(successInvoked)
+    }
+
+    // ─── T6: Botón descartar invoca onDiscard ────────────────────────────────
+
+    @Test
+    fun addTrackScreen_botonDescartar_invocaOnDiscard() {
+        var discardInvoked = false
+        setScreen(viewModelWith(), onDiscard = { discardInvoked = true })
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_DISCARD).performScrollTo().performClick()
+
+        assertTrue(discardInvoked)
+    }
+
+    // ─── T7: Error del repositorio muestra mensaje global ────────────────────
+
+    @Test
+    fun addTrackScreen_muestraMensajeDeError_cuandoRepositorioFalla() {
+        val vm = viewModelWith {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.failure(
+                java.io.IOException("sin red")
+            )
+        }
+        setScreen(vm)
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_NAME)
+            .performScrollTo().performTextInput("So What")
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_DURATION)
+            .performScrollTo().performTextInput("9:22")
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).performScrollTo().performClick()
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(AddTrackTestTags.ERROR_GLOBAL))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.ERROR_GLOBAL).assertExists()
+    }
+
+    // ─── T8: Botón deshabilitado durante carga ───────────────────────────────
+
+    @Test
+    fun addTrackScreen_botonDeshabilitado_duranteCarga() {
+        val vm = viewModelWith {
+            coEvery { addTrackToAlbum(albumId, any()) } coAnswers {
+                delay(10_000)
+                Result.success(createdTrack)
+            }
+        }
+        setScreen(vm)
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_NAME)
+            .performScrollTo().performTextInput("So What")
+        composeTestRule.onNodeWithTag(AddTrackTestTags.INPUT_DURATION)
+            .performScrollTo().performTextInput("9:22")
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).performScrollTo().performClick()
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.mainClock.advanceTimeBy(100)
+
+        composeTestRule.onNodeWithTag(AddTrackTestTags.BTN_SUBMIT).assertIsNotEnabled()
+    }
+}

--- a/app/src/androidTest/java/com/uniandes/vinilos/ui/albums/AlbumDetailScreenInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/uniandes/vinilos/ui/albums/AlbumDetailScreenInstrumentedTest.kt
@@ -1,12 +1,14 @@
 package com.uniandes.vinilos.ui.albums
 
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performScrollTo
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.uniandes.vinilos.model.Album
 import com.uniandes.vinilos.model.Performer
@@ -228,5 +230,130 @@ class AlbumDetailScreenInstrumentedTest {
         }
 
         composeTestRule.onNodeWithText("Poeta del pueblo").assertIsDisplayed()
+    }
+
+    // ─── HU08 - T7: Coleccionista ve el botón "AGREGAR" canción ──────────────
+
+    @Test
+    fun detailScreen_muestraBotonAgregarCancion_paraColeccionista() {
+        val viewModel = viewModelWith {
+            coEvery { getAlbums() } returns listOf(sampleAlbum)
+        }
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                AlbumDetailScreen(
+                    albumId = sampleAlbum.id,
+                    viewModel = viewModel,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(AlbumDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(AlbumDetailTestTags.BTN_ADD_TRACK)
+            .performScrollTo()
+            .assertIsDisplayed()
+    }
+
+    // ─── HU08 - T8: Visitante NO ve el botón "AGREGAR" canción ───────────────
+
+    @Test
+    fun detailScreen_ocultaBotonAgregarCancion_paraVisitante() {
+        val viewModel = viewModelWith {
+            coEvery { getAlbums() } returns listOf(sampleAlbum)
+        }
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                AlbumDetailScreen(
+                    albumId = sampleAlbum.id,
+                    viewModel = viewModel,
+                    userRole = UserRole.VISITOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(AlbumDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule
+            .onAllNodes(hasTestTag(AlbumDetailTestTags.BTN_ADD_TRACK))
+            .fetchSemanticsNodes()
+            .let { assertTrue("El visitante no debe ver el botón AGREGAR", it.isEmpty()) }
+    }
+
+    // ─── HU08 - T9: Click en "AGREGAR" invoca callback onAddTrack(albumId) ───
+
+    @Test
+    fun detailScreen_clickEnAgregar_invocaOnAddTrackConElAlbumId() {
+        var addTrackForId: Int? = null
+        val viewModel = viewModelWith {
+            coEvery { getAlbums() } returns listOf(sampleAlbum)
+        }
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                AlbumDetailScreen(
+                    albumId = sampleAlbum.id,
+                    viewModel = viewModel,
+                    userRole = UserRole.COLLECTOR,
+                    onAddTrack = { addTrackForId = it }
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(AlbumDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(AlbumDetailTestTags.BTN_ADD_TRACK)
+            .performScrollTo()
+            .performClick()
+
+        assertTrue(addTrackForId == sampleAlbum.id)
+    }
+
+    // ─── HU08 - T10: Álbum sin canciones muestra empty-state al coleccionista
+
+    @Test
+    fun detailScreen_muestraEmptyState_cuandoAlbumNoTieneCancionesYRolCollector() {
+        val albumSinTracks = sampleAlbum.copy(tracks = emptyList())
+        val viewModel = viewModelWith {
+            coEvery { getAlbums() } returns listOf(albumSinTracks)
+        }
+
+        composeTestRule.setContent {
+            VinilosTheme {
+                AlbumDetailScreen(
+                    albumId = albumSinTracks.id,
+                    viewModel = viewModel,
+                    userRole = UserRole.COLLECTOR
+                )
+            }
+        }
+
+        composeTestRule.waitUntil(timeoutMillis = 5_000) {
+            composeTestRule
+                .onAllNodes(hasTestTag(AlbumDetailTestTags.SCREEN))
+                .fetchSemanticsNodes().isNotEmpty()
+        }
+
+        composeTestRule.onNodeWithTag(AlbumDetailTestTags.TRACKS_EMPTY)
+            .performScrollTo()
+            .assertIsDisplayed()
+        composeTestRule.onNodeWithTag(AlbumDetailTestTags.BTN_ADD_TRACK)
+            .performScrollTo()
+            .assertIsDisplayed()
     }
 }

--- a/app/src/main/java/com/uniandes/vinilos/model/CreateTrackRequest.kt
+++ b/app/src/main/java/com/uniandes/vinilos/model/CreateTrackRequest.kt
@@ -1,0 +1,6 @@
+package com.uniandes.vinilos.model
+
+data class CreateTrackRequest(
+    val name: String,
+    val duration: String
+)

--- a/app/src/main/java/com/uniandes/vinilos/network/VinilosApi.kt
+++ b/app/src/main/java/com/uniandes/vinilos/network/VinilosApi.kt
@@ -2,10 +2,12 @@ package com.uniandes.vinilos.network
 
 import com.uniandes.vinilos.model.Album
 import com.uniandes.vinilos.model.CreateAlbumRequest
+import com.uniandes.vinilos.model.CreateTrackRequest
 import com.uniandes.vinilos.model.Collector
 import com.uniandes.vinilos.model.Performer
 import com.uniandes.vinilos.model.PerformerPrize
 import com.uniandes.vinilos.model.Prize
+import com.uniandes.vinilos.model.Track
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -27,6 +29,12 @@ interface VinilosApi {
  
     @GET("albums/{id}")
     suspend fun getAlbum(@Path("id") id: Int): Album
+
+    @POST("albums/{albumId}/tracks")
+    suspend fun addTrackToAlbum(
+        @Path("albumId") albumId: Int,
+        @Body body: CreateTrackRequest
+    ): Track
 
     @GET("collectors")
     suspend fun getCollectors(): List<Collector>

--- a/app/src/main/java/com/uniandes/vinilos/repository/AlbumRepository.kt
+++ b/app/src/main/java/com/uniandes/vinilos/repository/AlbumRepository.kt
@@ -5,6 +5,8 @@ import com.uniandes.vinilos.database.toAlbum
 import com.uniandes.vinilos.database.toEntity
 import com.uniandes.vinilos.model.Album
 import com.uniandes.vinilos.model.CreateAlbumRequest
+import com.uniandes.vinilos.model.CreateTrackRequest
+import com.uniandes.vinilos.model.Track
 import com.uniandes.vinilos.network.NetworkServiceAdapter
 import com.uniandes.vinilos.network.VinilosApi
 
@@ -35,7 +37,19 @@ class AlbumRepository(
             Result.failure(e)
         }
     }
- 
+
+    suspend fun addTrackToAlbum(albumId: Int, request: CreateTrackRequest): Result<Track> {
+        return try {
+            val created = api.addTrackToAlbum(albumId, request)
+            // Invalidamos la caché para que la próxima lectura traiga el álbum
+            // con el nuevo track incluido en su lista.
+            dao.deleteAll()
+            Result.success(created)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
     private suspend fun fetchAndCache(): List<Album> {
         val albums = api.getAlbums().map { it.copy(releaseDate = it.releaseDate.take(4)) }
         dao.insertAll(albums.map { it.toEntity() })

--- a/app/src/main/java/com/uniandes/vinilos/ui/albums/AddTrackScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/albums/AddTrackScreen.kt
@@ -1,0 +1,247 @@
+package com.uniandes.vinilos.ui.albums
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AddTrackScreen(
+    albumId: Int,
+    albumName: String,
+    viewModel: CreateTrackViewModel,
+    onSuccess: () -> Unit,
+    onDiscard: () -> Unit
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val name by viewModel.name.collectAsStateWithLifecycle()
+    val duration by viewModel.duration.collectAsStateWithLifecycle()
+
+    val nameError by viewModel.nameError.collectAsStateWithLifecycle()
+    val durationError by viewModel.durationError.collectAsStateWithLifecycle()
+
+    LaunchedEffect(uiState) {
+        if (uiState is CreateTrackUiState.Success) {
+            onSuccess()
+            viewModel.resetState()
+        }
+    }
+
+    val backgroundColor = MaterialTheme.colorScheme.background
+    val onBackground = MaterialTheme.colorScheme.onBackground
+    val accent = Color(0xFF8B2E1A)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(backgroundColor)
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 24.dp)
+            .testTag(AddTrackTestTags.SCREEN)
+    ) {
+        Spacer(modifier = Modifier.height(24.dp))
+
+        Text(
+            text = "TRACK ASSOCIATION",
+            fontSize = 11.sp,
+            letterSpacing = 2.sp,
+            color = accent,
+            fontWeight = FontWeight.Medium
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        Text(
+            text = "Asociar canción",
+            fontSize = 34.sp,
+            fontWeight = FontWeight.Bold,
+            color = onBackground
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Agrega una canción al álbum \"$albumName\". Documenta el orden, la duración exacta y mantén el archivo curado.",
+            fontSize = 14.sp,
+            color = onBackground.copy(alpha = 0.6f),
+            lineHeight = 20.sp
+        )
+
+        Spacer(modifier = Modifier.height(28.dp))
+
+        TrackField(
+            label = "NOMBRE DE LA CANCIÓN",
+            value = name,
+            onValueChange = { viewModel.name.value = it },
+            placeholder = "Ej. So What",
+            error = nameError,
+            testTag = AddTrackTestTags.INPUT_NAME
+        )
+
+        Spacer(modifier = Modifier.height(20.dp))
+
+        TrackField(
+            label = "DURACIÓN (mm:ss)",
+            value = duration,
+            onValueChange = { viewModel.duration.value = it },
+            placeholder = "3:45",
+            error = durationError,
+            keyboardType = KeyboardType.Number,
+            testTag = AddTrackTestTags.INPUT_DURATION
+        )
+
+        Spacer(modifier = Modifier.height(36.dp))
+
+        if (uiState is CreateTrackUiState.Error) {
+            Text(
+                text = (uiState as CreateTrackUiState.Error).message,
+                color = MaterialTheme.colorScheme.error,
+                fontSize = 13.sp,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 12.dp)
+                    .testTag(AddTrackTestTags.ERROR_GLOBAL)
+            )
+        }
+
+        Button(
+            onClick = { viewModel.submitTrack(albumId) },
+            enabled = uiState !is CreateTrackUiState.Loading,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(52.dp)
+                .testTag(AddTrackTestTags.BTN_SUBMIT)
+                .semantics { contentDescription = AddTrackTestTags.BTN_SUBMIT },
+            shape = RoundedCornerShape(4.dp),
+            colors = ButtonDefaults.buttonColors(
+                containerColor = onBackground,
+                contentColor = backgroundColor
+            )
+        ) {
+            if (uiState is CreateTrackUiState.Loading) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    color = backgroundColor,
+                    strokeWidth = 2.dp
+                )
+            } else {
+                Text(
+                    text = "ASOCIAR CANCIÓN →",
+                    fontSize = 13.sp,
+                    letterSpacing = 1.5.sp,
+                    fontWeight = FontWeight.SemiBold
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        TextButton(
+            onClick = onDiscard,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(AddTrackTestTags.BTN_DISCARD)
+        ) {
+            Text(
+                text = "DESCARTAR",
+                fontSize = 12.sp,
+                letterSpacing = 1.5.sp,
+                color = onBackground.copy(alpha = 0.5f)
+            )
+        }
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        Text(
+            text = "REF. AV-2024-HU08",
+            fontSize = 10.sp,
+            letterSpacing = 1.sp,
+            color = onBackground.copy(alpha = 0.3f)
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun TrackField(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+    placeholder: String,
+    error: String?,
+    testTag: String,
+    keyboardType: KeyboardType = KeyboardType.Text
+) {
+    val onBackground = MaterialTheme.colorScheme.onBackground
+    Column {
+        Text(
+            text = label,
+            fontSize = 10.sp,
+            letterSpacing = 1.5.sp,
+            color = onBackground.copy(alpha = 0.5f),
+            fontWeight = FontWeight.SemiBold
+        )
+        Spacer(modifier = Modifier.height(6.dp))
+        OutlinedTextField(
+            value = value,
+            onValueChange = onValueChange,
+            placeholder = {
+                Text(
+                    placeholder,
+                    fontStyle = FontStyle.Italic,
+                    color = onBackground.copy(alpha = 0.35f)
+                )
+            },
+            isError = error != null,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag(testTag)
+                .semantics { contentDescription = testTag },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(keyboardType = keyboardType),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = onBackground,
+                unfocusedBorderColor = onBackground.copy(alpha = 0.25f),
+                focusedLabelColor = onBackground,
+                cursorColor = onBackground
+            )
+        )
+        if (error != null) {
+            Text(
+                text = error,
+                color = MaterialTheme.colorScheme.error,
+                fontSize = 12.sp,
+                modifier = Modifier
+                    .padding(top = 4.dp)
+                    .testTag("${testTag}_error")
+            )
+        }
+    }
+}
+
+object AddTrackTestTags {
+    const val SCREEN         = "add_track_screen"
+    const val INPUT_NAME     = "input_track_name"
+    const val INPUT_DURATION = "input_track_duration"
+    const val BTN_SUBMIT     = "btn_submit_track"
+    const val BTN_DISCARD    = "btn_discard_track"
+    const val ERROR_GLOBAL   = "add_track_error"
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/albums/AddTrackScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/albums/AddTrackScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
@@ -20,15 +20,16 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddTrackScreen(
     albumId: Int,
     albumName: String,
-    viewModel: CreateTrackViewModel,
-    onSuccess: () -> Unit,
-    onDiscard: () -> Unit
+    viewModel: CreateTrackViewModel = viewModel(factory = CreateTrackViewModel.factory(LocalContext.current)),
+    onSuccess: () -> Unit = {},
+    onDiscard: () -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val name by viewModel.name.collectAsStateWithLifecycle()
@@ -46,7 +47,7 @@ fun AddTrackScreen(
 
     val backgroundColor = MaterialTheme.colorScheme.background
     val onBackground = MaterialTheme.colorScheme.onBackground
-    val accent = Color(0xFF8B2E1A)
+    val accent = MaterialTheme.colorScheme.primary
 
     Column(
         modifier = Modifier

--- a/app/src/main/java/com/uniandes/vinilos/ui/albums/AlbumDetailScreen.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/albums/AlbumDetailScreen.kt
@@ -35,6 +35,7 @@ fun AlbumDetailScreen(
     viewModel: AlbumViewModel = viewModel(factory = AlbumViewModel.factory(LocalContext.current)),
     onBack: () -> Unit = {},
     onMenuClick: () -> Unit = {},
+    onAddTrack: (Int) -> Unit = {},
     userRole: UserRole? = null
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -201,28 +202,61 @@ fun AlbumDetailScreen(
                     }
                 }
 
-                if (album.tracks.isNotEmpty()) {
+                val isCollector = userRole == UserRole.COLLECTOR
+                if (album.tracks.isNotEmpty() || isCollector) {
                     Spacer(modifier = Modifier.height(24.dp))
                     HorizontalDivider()
                     Spacer(modifier = Modifier.height(16.dp))
 
-                    Text(
-                        text = "CANCIONES",
-                        fontSize = 11.sp,
-                        letterSpacing = 2.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.primary
-                    )
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "CANCIONES",
+                            fontSize = 11.sp,
+                            letterSpacing = 2.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+
+                        if (isCollector) {
+                            TextButton(
+                                onClick = { onAddTrack(albumId) },
+                                modifier = Modifier.testTag(AlbumDetailTestTags.BTN_ADD_TRACK)
+                            ) {
+                                Text(
+                                    text = "+ AGREGAR",
+                                    fontSize = 11.sp,
+                                    letterSpacing = 1.5.sp,
+                                    fontWeight = FontWeight.SemiBold,
+                                    color = MaterialTheme.colorScheme.primary
+                                )
+                            }
+                        }
+                    }
 
                     Spacer(modifier = Modifier.height(8.dp))
 
-                    album.tracks.forEachIndexed { index, track ->
-                        TrackRow(index = index + 1, track = track)
-                        if (index < album.tracks.lastIndex) {
-                            HorizontalDivider(
-                                modifier = Modifier.padding(vertical = 0.dp),
-                                color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
-                            )
+                    if (album.tracks.isEmpty()) {
+                        Text(
+                            text = "Aún no hay canciones asociadas a este álbum.",
+                            fontSize = 13.sp,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier
+                                .padding(vertical = 12.dp)
+                                .testTag(AlbumDetailTestTags.TRACKS_EMPTY)
+                        )
+                    } else {
+                        album.tracks.forEachIndexed { index, track ->
+                            TrackRow(index = index + 1, track = track)
+                            if (index < album.tracks.lastIndex) {
+                                HorizontalDivider(
+                                    modifier = Modifier.padding(vertical = 0.dp),
+                                    color = MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f)
+                                )
+                            }
                         }
                     }
                 }
@@ -261,9 +295,11 @@ private fun TrackRow(index: Int, track: Track) {
 }
 
 object AlbumDetailTestTags {
-    const val SCREEN  = "album_detail_screen"
-    const val LOADING = "album_detail_loading"
-    const val BACK    = "top_bar_back_button"
+    const val SCREEN         = "album_detail_screen"
+    const val LOADING        = "album_detail_loading"
+    const val BACK           = "top_bar_back_button"
+    const val BTN_ADD_TRACK  = "album_detail_btn_add_track"
+    const val TRACKS_EMPTY   = "album_detail_tracks_empty"
 }
 
 @Preview(showBackground = true, showSystemUi = true)

--- a/app/src/main/java/com/uniandes/vinilos/ui/albums/CreateTrackViewModel.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/albums/CreateTrackViewModel.kt
@@ -1,0 +1,112 @@
+package com.uniandes.vinilos.ui.albums
+
+import android.content.Context
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.uniandes.vinilos.database.VinilosDatabase
+import com.uniandes.vinilos.model.CreateTrackRequest
+import com.uniandes.vinilos.model.Track
+import com.uniandes.vinilos.repository.AlbumRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed class CreateTrackUiState {
+    object Idle : CreateTrackUiState()
+    object Loading : CreateTrackUiState()
+    data class Success(val track: Track) : CreateTrackUiState()
+    data class Error(val message: String) : CreateTrackUiState()
+}
+
+class CreateTrackViewModel(
+    private val repository: AlbumRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<CreateTrackUiState>(CreateTrackUiState.Idle)
+    val uiState: StateFlow<CreateTrackUiState> = _uiState.asStateFlow()
+
+    val name = MutableStateFlow("")
+    val duration = MutableStateFlow("")
+
+    private val _nameError = MutableStateFlow<String?>(null)
+    val nameError: StateFlow<String?> = _nameError.asStateFlow()
+
+    private val _durationError = MutableStateFlow<String?>(null)
+    val durationError: StateFlow<String?> = _durationError.asStateFlow()
+
+    fun submitTrack(albumId: Int) {
+        if (!validate()) return
+
+        viewModelScope.launch {
+            _uiState.value = CreateTrackUiState.Loading
+
+            val request = CreateTrackRequest(
+                name = name.value.trim(),
+                duration = duration.value.trim()
+            )
+
+            val result = repository.addTrackToAlbum(albumId, request)
+            _uiState.value = if (result.isSuccess) {
+                CreateTrackUiState.Success(result.getOrThrow())
+            } else {
+                CreateTrackUiState.Error(
+                    result.exceptionOrNull()?.message ?: "Error al asociar la canción"
+                )
+            }
+        }
+    }
+
+    fun resetState() {
+        _uiState.value = CreateTrackUiState.Idle
+        name.value = ""
+        duration.value = ""
+        _nameError.value = null
+        _durationError.value = null
+    }
+
+    private fun validate(): Boolean {
+        var isValid = true
+
+        _nameError.value = when {
+            name.value.isBlank() -> {
+                isValid = false
+                "El nombre de la canción es obligatorio"
+            }
+            name.value.trim().length > 80 -> {
+                isValid = false
+                "El nombre no puede superar 80 caracteres"
+            }
+            else -> null
+        }
+
+        _durationError.value = when {
+            duration.value.isBlank() -> {
+                isValid = false
+                "La duración es obligatoria"
+            }
+            !DURATION_REGEX.matches(duration.value.trim()) -> {
+                isValid = false
+                "Formato esperado mm:ss (ej. 3:45)"
+            }
+            else -> null
+        }
+
+        return isValid
+    }
+
+    companion object {
+        // Acepta m:ss o mm:ss, segundos siempre 00..59. Ej: 3:45, 12:08, 0:30.
+        private val DURATION_REGEX = Regex("^([0-9]|[1-9][0-9]):[0-5][0-9]$")
+
+        fun factory(context: Context): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    val dao = VinilosDatabase.getDatabase(context).albumDao()
+                    return CreateTrackViewModel(AlbumRepository(dao)) as T
+                }
+            }
+    }
+}

--- a/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/uniandes/vinilos/ui/navigation/AppNavigation.kt
@@ -55,11 +55,13 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.uniandes.vinilos.AppViewModel
 import com.uniandes.vinilos.model.UserRole
+import com.uniandes.vinilos.ui.albums.AddTrackScreen
 import com.uniandes.vinilos.ui.albums.AlbumDetailScreen
 import com.uniandes.vinilos.ui.albums.AlbumListScreen
 import com.uniandes.vinilos.ui.albums.AlbumViewModel
 import com.uniandes.vinilos.ui.albums.CreateAlbumScreen
 import com.uniandes.vinilos.ui.albums.CreateAlbumViewModel
+import com.uniandes.vinilos.ui.albums.CreateTrackViewModel
 import com.uniandes.vinilos.ui.artists.ArtistDetailScreen
 import com.uniandes.vinilos.ui.artists.ArtistListScreen
 import com.uniandes.vinilos.ui.artists.ArtistViewModel
@@ -85,6 +87,9 @@ sealed class Screen(val route: String) {
         fun createRoute(albumId: Int) = "album_detail/$albumId"
     }
     object AlbumCreate : Screen("album_create")
+    object AlbumAddTrack : Screen("album_add_track/{albumId}") {
+        fun createRoute(albumId: Int) = "album_add_track/$albumId"
+    }
     object ArtistList : Screen("artist_list")
     object ArtistDetail : Screen("artist_detail/{artistId}") {
         fun createRoute(artistId: Int) = "artist_detail/$artistId"
@@ -134,6 +139,7 @@ fun AppNavigation(
     val collectorViewModel: CollectorViewModel = viewModel(factory = CollectorViewModel.factory(context))
     val prizeViewModel: PrizeViewModel = viewModel(factory = PrizeViewModel.factory(context))
     val createAlbumViewModel: CreateAlbumViewModel = viewModel(factory = CreateAlbumViewModel.factory(context))
+    val createTrackViewModel: CreateTrackViewModel = viewModel(factory = CreateTrackViewModel.factory(context))
     val favoritePerformersViewModel: FavoritePerformersViewModel = viewModel(factory = FavoritePerformersViewModel.factory(context))
 
     val isDetailScreen = currentRoute?.startsWith("album_detail") == true ||
@@ -142,7 +148,8 @@ fun AppNavigation(
             currentRoute?.startsWith("favorite_performers") == true ||
             currentRoute?.startsWith("prize_associate") == true
 
-    val isCreateScreen = currentRoute == Screen.AlbumCreate.route
+    val isCreateScreen = currentRoute == Screen.AlbumCreate.route ||
+            currentRoute?.startsWith("album_add_track") == true
 
     var isBarVisible by remember { mutableStateOf(true) }
 
@@ -307,7 +314,27 @@ fun AppNavigation(
                         viewModel = albumViewModel,
                         onBack = { navController.navigateUp() },
                         onMenuClick = onMenuClick,
-                        userRole = userRole 
+                        onAddTrack = {
+                            navController.navigate(Screen.AlbumAddTrack.createRoute(it))
+                        },
+                        userRole = userRole
+                    )
+                }
+                composable(
+                    route = Screen.AlbumAddTrack.route,
+                    arguments = listOf(navArgument("albumId") { type = NavType.IntType })
+                ) { backStackEntry ->
+                    val albumId = backStackEntry.arguments?.getInt("albumId") ?: return@composable
+                    val album = albumViewModel.findById(albumId)
+                    AddTrackScreen(
+                        albumId = albumId,
+                        albumName = album?.name ?: "este álbum",
+                        viewModel = createTrackViewModel,
+                        onSuccess = {
+                            albumViewModel.refresh()
+                            navController.popBackStack()
+                        },
+                        onDiscard = { navController.popBackStack() }
                     )
                 }
                 composable(Screen.ArtistList.route) {

--- a/app/src/test/java/com/uniandes/vinilos/repository/AlbumRepositoryTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/repository/AlbumRepositoryTest.kt
@@ -3,6 +3,7 @@ package com.uniandes.vinilos.repository
 import com.uniandes.vinilos.database.dao.AlbumDao
 import com.uniandes.vinilos.database.entities.AlbumEntity
 import com.uniandes.vinilos.model.Album
+import com.uniandes.vinilos.model.CreateTrackRequest
 import com.uniandes.vinilos.model.Performer
 import com.uniandes.vinilos.model.Track
 import com.uniandes.vinilos.network.VinilosApi
@@ -106,6 +107,35 @@ class AlbumRepositoryTest {
             kotlinx.coroutines.runBlocking { repository.getAlbums() }
         }
         assertEquals("sin red", thrown.message)
+    }
+
+    // ─── HU08 — addTrackToAlbum ───────────────────────────────────────────────
+
+    @Test
+    fun `addTrackToAlbum llama al API, invalida la cache y devuelve Success`() = runTest {
+        val request = CreateTrackRequest(name = "So What", duration = "9:22")
+        val created = Track(id = 101, name = "So What", duration = "9:22")
+        coEvery { api.addTrackToAlbum(7, request) } returns created
+
+        val result = repository.addTrackToAlbum(7, request)
+
+        assertTrue(result.isSuccess)
+        assertEquals(101, result.getOrNull()?.id)
+        coVerify(exactly = 1) { api.addTrackToAlbum(7, request) }
+        coVerify(exactly = 1) { dao.deleteAll() }
+    }
+
+    @Test
+    fun `addTrackToAlbum devuelve Failure cuando el API lanza excepcion`() = runTest {
+        val request = CreateTrackRequest(name = "Track", duration = "3:00")
+        coEvery { api.addTrackToAlbum(7, request) } throws IOException("sin red")
+
+        val result = repository.addTrackToAlbum(7, request)
+
+        assertTrue(result.isFailure)
+        assertEquals("sin red", result.exceptionOrNull()?.message)
+        // No debe invalidar cache si la red falló
+        coVerify(exactly = 0) { dao.deleteAll() }
     }
 
     private companion object {

--- a/app/src/test/java/com/uniandes/vinilos/ui/albums/CreateTrackViewModelTest.kt
+++ b/app/src/test/java/com/uniandes/vinilos/ui/albums/CreateTrackViewModelTest.kt
@@ -1,0 +1,250 @@
+package com.uniandes.vinilos.ui.albums
+
+import com.uniandes.vinilos.model.CreateTrackRequest
+import com.uniandes.vinilos.model.Track
+import com.uniandes.vinilos.repository.AlbumRepository
+import com.uniandes.vinilos.testing.MainDispatcherRule
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CreateTrackViewModelTest {
+
+    @get:Rule
+    val mainDispatcherRule = MainDispatcherRule()
+
+    private val albumId = 7
+    private val createdTrack = Track(
+        id = 101,
+        name = "So What",
+        duration = "9:22"
+    )
+
+    private fun viewModel(repoBlock: AlbumRepository.() -> Unit = {}): CreateTrackViewModel {
+        val repo = mockk<AlbumRepository>(relaxed = true).apply(repoBlock)
+        return CreateTrackViewModel(repo)
+    }
+
+    // ─── Estado inicial ───────────────────────────────────────────────────────
+
+    @Test
+    fun `estado inicial es Idle`() = runTest {
+        val vm = viewModel()
+        assertTrue(vm.uiState.value is CreateTrackUiState.Idle)
+        assertEquals("", vm.name.value)
+        assertEquals("", vm.duration.value)
+        assertNull(vm.nameError.value)
+        assertNull(vm.durationError.value)
+    }
+
+    // ─── Validaciones ─────────────────────────────────────────────────────────
+
+    @Test
+    fun `submitTrack con formulario vacio no llama al repositorio`() = runTest {
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        val vm = CreateTrackViewModel(repo)
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.addTrackToAlbum(any(), any()) }
+        assertTrue(vm.uiState.value is CreateTrackUiState.Idle)
+    }
+
+    @Test
+    fun `submitTrack con nombre vacio muestra error de nombre`() = runTest {
+        val vm = viewModel()
+        vm.duration.value = "3:45"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals("El nombre de la canción es obligatorio", vm.nameError.value)
+        assertTrue(vm.uiState.value is CreateTrackUiState.Idle)
+    }
+
+    @Test
+    fun `submitTrack con nombre demasiado largo muestra error`() = runTest {
+        val vm = viewModel()
+        vm.name.value = "x".repeat(81)
+        vm.duration.value = "3:45"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals("El nombre no puede superar 80 caracteres", vm.nameError.value)
+    }
+
+    @Test
+    fun `submitTrack con duracion vacia muestra error de duracion`() = runTest {
+        val vm = viewModel()
+        vm.name.value = "So What"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals("La duración es obligatoria", vm.durationError.value)
+    }
+
+    @Test
+    fun `submitTrack con formato de duracion invalido muestra error`() = runTest {
+        val vm = viewModel()
+        vm.name.value = "So What"
+        vm.duration.value = "9 minutos"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals("Formato esperado mm:ss (ej. 3:45)", vm.durationError.value)
+    }
+
+    @Test
+    fun `submitTrack con segundos mayores a 59 muestra error de formato`() = runTest {
+        val vm = viewModel()
+        vm.name.value = "So What"
+        vm.duration.value = "3:75"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals("Formato esperado mm:ss (ej. 3:45)", vm.durationError.value)
+    }
+
+    @Test
+    fun `submitTrack acepta duracion en formato m_ss`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.success(createdTrack)
+        }
+        vm.name.value = "Cancion corta"
+        vm.duration.value = "0:30"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertNull(vm.durationError.value)
+        assertTrue(vm.uiState.value is CreateTrackUiState.Success)
+    }
+
+    @Test
+    fun `submitTrack acepta duracion en formato mm_ss largo`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.success(createdTrack)
+        }
+        vm.name.value = "Cancion larga"
+        vm.duration.value = "12:08"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertNull(vm.durationError.value)
+        assertTrue(vm.uiState.value is CreateTrackUiState.Success)
+    }
+
+    // ─── Flujo exitoso ────────────────────────────────────────────────────────
+
+    @Test
+    fun `submitTrack con datos validos emite Success con el track creado`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.success(createdTrack)
+        }
+        vm.name.value = "So What"
+        vm.duration.value = "9:22"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is CreateTrackUiState.Success)
+        assertEquals(101, (state as CreateTrackUiState.Success).track.id)
+        assertEquals("So What", state.track.name)
+    }
+
+    @Test
+    fun `submitTrack envia el albumId correcto al repositorio`() = runTest {
+        var capturedAlbumId: Int? = null
+        var capturedRequest: CreateTrackRequest? = null
+        val repo = mockk<AlbumRepository>(relaxed = true)
+        coEvery { repo.addTrackToAlbum(any(), any()) } coAnswers {
+            capturedAlbumId = firstArg()
+            capturedRequest = secondArg()
+            Result.success(createdTrack)
+        }
+        val vm = CreateTrackViewModel(repo)
+        vm.name.value = "  So What  " // espacios al margen
+        vm.duration.value = " 9:22 "
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        assertEquals(albumId, capturedAlbumId)
+        // Verifica que el ViewModel hace trim antes de enviar
+        assertEquals("So What", capturedRequest?.name)
+        assertEquals("9:22", capturedRequest?.duration)
+    }
+
+    // ─── Flujo de error ───────────────────────────────────────────────────────
+
+    @Test
+    fun `submitTrack emite Error cuando el repositorio falla`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.failure(IOException("sin red"))
+        }
+        vm.name.value = "So What"
+        vm.duration.value = "9:22"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is CreateTrackUiState.Error)
+        assertEquals("sin red", (state as CreateTrackUiState.Error).message)
+    }
+
+    @Test
+    fun `submitTrack emite Error con mensaje generico si la excepcion no tiene mensaje`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.failure(RuntimeException())
+        }
+        vm.name.value = "So What"
+        vm.duration.value = "9:22"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is CreateTrackUiState.Error)
+        assertEquals("Error al asociar la canción", (state as CreateTrackUiState.Error).message)
+    }
+
+    // ─── resetState ───────────────────────────────────────────────────────────
+
+    @Test
+    fun `resetState vuelve a Idle y limpia campos y errores`() = runTest {
+        val vm = viewModel {
+            coEvery { addTrackToAlbum(albumId, any()) } returns Result.success(createdTrack)
+        }
+        vm.name.value = "So What"
+        vm.duration.value = "9:22"
+
+        vm.submitTrack(albumId)
+        advanceUntilIdle()
+
+        vm.resetState()
+
+        assertTrue(vm.uiState.value is CreateTrackUiState.Idle)
+        assertEquals("", vm.name.value)
+        assertEquals("", vm.duration.value)
+        assertNull(vm.nameError.value)
+        assertNull(vm.durationError.value)
+    }
+}

--- a/kraken/features/add_track.feature
+++ b/kraken/features/add_track.feature
@@ -1,0 +1,69 @@
+Feature: Asociar canción al álbum (HU08)
+  @user1 @mobile
+  Scenario: Como coleccionista asocio una canción nueva al álbum desde su detalle
+    Given I wait
+    Then I select role if needed
+    Then I wait
+    Then I ensure collector role
+    Then I wait
+    Then I tap on element with accessibility id "nav_álbumes"
+    Then I wait
+    Then I wait
+    Then I see the text "Álbumes"
+    Then I scroll down
+    Then I see the text "Buscando América"
+    Then I tap on element with text containing "Buscando América"
+    Then I wait
+    Then I see the text "Salsa"
+    Then I scroll down
+    Then I scroll down
+    Then I see the text "CANCIONES"
+    Then I tap on element with accessibility id "album_detail_btn_add_track"
+    Then I wait
+    Then I see the text "Asociar canción"
+    Then I see the text "TRACK ASSOCIATION"
+    Then I type "Cancion Kraken HU08" on element with id "input_track_name"
+    Then I type "3:45" on element with id "input_track_duration"
+    Then I scroll down
+    Then I tap on element with accessibility id "btn_submit_track"
+    Then I wait
+    Then I wait
+    Then I wait
+    Then I see the text "Buscando América"
+    Then I tap on element with accessibility id "Volver"
+    Then I wait
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait
+
+  @user2 @mobile
+  Scenario: Validaciones de formulario: campos vacíos muestran errores
+    Given I wait
+    Then I select role if needed
+    Then I wait
+    Then I ensure collector role
+    Then I wait
+    Then I tap on element with accessibility id "nav_álbumes"
+    Then I wait
+    Then I wait
+    Then I see the text "Álbumes"
+    Then I scroll down
+    Then I see the text "Buscando América"
+    Then I tap on element with text containing "Buscando América"
+    Then I wait
+    Then I scroll down
+    Then I scroll down
+    Then I see the text "CANCIONES"
+    Then I tap on element with accessibility id "album_detail_btn_add_track"
+    Then I wait
+    Then I see the text "Asociar canción"
+    Then I scroll down
+    Then I tap on element with accessibility id "btn_submit_track"
+    Then I wait
+    Then I see the text "El nombre de la canción es obligatorio"
+    Then I see the text "La duración es obligatoria"
+    Then I tap on element with accessibility id "btn_discard_track"
+    Then I wait
+    Then I tap on element with accessibility id "Volver"
+    Then I wait
+    Then I tap on element with accessibility id "nav_vinilos"
+    Then I wait


### PR DESCRIPTION
Permite a un coleccionista asociar canciones a un álbum desde su pantalla de detalle. La sección "CANCIONES" ahora muestra un botón + AGREGAR condicional al rol; abre una pantalla de formulario con validaciones de nombre y duración, hace POST al endpoint del back, invalida el caché de álbumes y al volver al detalle la canción ya aparece en la lista. Los visitantes siguen viendo el listado de tracks en read-only.

**Reglas de negocio implementadas**
- Permisos: solo UserRole.COLLECTOR ve el botón + AGREGAR y puede llegar a la pantalla.
- Validación de nombre: obligatorio, máx. 80 caracteres, se hace trim() antes de enviar.
- Validación de duración: regex ^([0-9]|[1-9][0-9]):[0-5][0-9]$. Acepta 0:30, 3:45, 12:08; rechaza 3:75, nueve minutos, 345.
- Refresco del detalle: al asociar OK, el repository borra el caché Room → albumViewModel.refresh() recarga del API → el detalle muestra la canción nueva sin tener que cerrar la app.
- Empty state: un álbum sin canciones muestra "Aún no hay canciones asociadas a este álbum." al coleccionista (con el botón AGREGAR visible). Para visitantes la sección queda oculta.